### PR TITLE
Fix problem deploying without cassandra

### DIFF
--- a/charts/pega/templates/pega-environment-config.yaml
+++ b/charts/pega/templates/pega-environment-config.yaml
@@ -20,7 +20,7 @@ data:
   # Whether to enable connecting to a cassandra cluster.  "true" for enabled, "false for disabled"
   CASSANDRA_CLUSTER: "{{ include "cassandraEnabled" . }}"
   # Comma separated list of cassandra hosts
-  CASSANDRA_NODES: {{ include "cassandraNodes" . }}
+  CASSANDRA_NODES: "{{ include "cassandraNodes" . }}"
   # Port to connect to cassandra with
   CASSANDRA_PORT: "{{ .Values.dds.port }}"
   # Username for Cassandra DB


### PR DESCRIPTION
When Cassandra was not deployed, the CASSANDRA_NODES field is missing rather than empty.  It should be present because the batch tier depends on it being referenced as an env variable.