### PR TITLE
Fixes apiVersion for pega_hpa template to support Kubernetes v1.16.x.

### DIFF
--- a/charts/pega/templates/_pega_hpa.tpl
+++ b/charts/pega/templates/_pega_hpa.tpl
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ .root.Release.Namespace }}
 spec:
   scaleTargetRef:
-    apiVersion: extensions/v1beta1
+    apiVersion: apps/v1
     kind: Deployment
     name: {{ .deploymentName | quote }}
   {{- if .hpa.minReplicas }}

--- a/terratest/src/test/deployment_utility.go
+++ b/terratest/src/test/deployment_utility.go
@@ -365,9 +365,9 @@ func SplitAndVerifyPegaHPAs(t *testing.T, helmChartPath string, options *helm.Op
 		if index >= 0 && index <= 1 {
 			helm.UnmarshalK8SYaml(t, hpaInfo, &pegaHpaObj)
 			if index == 0 {
-				VerifyPegaHpa(t, &pegaHpaObj, hpa{"pega-web-hpa", "pega-web", "Deployment", "extensions/v1beta1"})
+				VerifyPegaHpa(t, &pegaHpaObj, hpa{"pega-web-hpa", "pega-web", "Deployment", "apps/v1"})
 			} else {
-				VerifyPegaHpa(t, &pegaHpaObj, hpa{"pega-batch-hpa", "pega-batch", "Deployment", "extensions/v1beta1"})
+				VerifyPegaHpa(t, &pegaHpaObj, hpa{"pega-batch-hpa", "pega-batch", "Deployment", "apps/v1"})
 			}
 		}
 	}


### PR DESCRIPTION
This fixes the broken auto-scaler caused due to the HPA template still using a deprecated API Version. 

This fixes #47.