### PR TITLE
Add support for custom service and ingress annotations

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -206,9 +206,9 @@ requestor:
   passivationTimeSec: 900
 ```
 
-### service (*Optional*)
+### service and ingress (*Optional*)
 
-Specify that the Kubernetes service block is expose to other Kubernetes run services, or externally to systems outside the environment.  The name of the service will be based on the tier's name, so if your tier is `"web"`, your service name will be `"pega-web"`.  If you omit `service`, no Kubernetes service object is created for the tier during the deployment. For more information on services, see the [Kubernetes Documentation](https://kubernetes.io/docs/concepts/services-networking/service/]).
+Specify the service block to expose a Pega tier to other Kubernetes run services, or externally to other systems .  The name of the service will be based on the tier's name, so if your tier is `"web"`, your service name will be `"pega-web"`.  If you omit `service`, no Kubernetes service object is created for the tier during the deployment. For more information on services, see the [Kubernetes Documentation](https://kubernetes.io/docs/concepts/services-networking/service/]).
 
 Configuration parameters:
 
@@ -225,6 +225,7 @@ service:
   targetPort: 1234
 ```
 
+Annotations to the service or ingress Kubernetes objects may be applied by setting `service.annotations` or `ingress.annotations` as required.  This is used for advanced load balancer or other ingress configuration. Specifying a custom set of annotations will result in them being used *instead of* the default configurations.
 
 ### Managing Resources
 

--- a/charts/pega/templates/_pega-k8s-ingress.tpl
+++ b/charts/pega/templates/_pega-k8s-ingress.tpl
@@ -6,8 +6,15 @@ metadata:
   name: {{ .name }}
   namespace: {{ .root.Release.Namespace }}
   annotations:
+{{- if .node.ingress }}
+{{- if .node.ingress.annotations }}
+    # Custom annotations
+{{ toYaml .node.ingress.annotations | indent 4 }}
+{{- end }}
+{{- else }}
     # Ingress class used is 'traefik'
     kubernetes.io/ingress.class: traefik
+{{- end }}
 spec:
   rules:
   # The calls will be redirected from {{ .node.domain }} to below mentioned backend serviceName and servicePort.

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -6,8 +6,12 @@ metadata:
   # Name of the service for
   name: {{ .name }}
   namespace: {{ .root.Release.Namespace }}
-  {{- if and (ne .root.Values.global.provider "eks") (ne .root.Values.global.provider "openshift") }}
   annotations: 
+{{- if .node.service.annotations }}
+    # Custom annotations
+{{ toYaml .node.service.annotations | indent 4 }}
+{{- else }}
+  {{- if and (ne .root.Values.global.provider "eks") (ne .root.Values.global.provider "openshift") }}
     # Enable backend sticky sessions
     traefik.ingress.kubernetes.io/affinity: 'true'
     # Override the default wrr load balancer algorithm.
@@ -18,13 +22,14 @@ metadata:
     # Manually set the cookie name for sticky sessions
     traefik.ingress.kubernetes.io/session-cookie-name: UNIQUE-PEGA-COOKIE-NAME
   {{ end }}
+{{- end }}
 spec:
-  type: {{ .serviceType | default "LoadBalancer" }}
+  type: {{ .node.service.serviceType | default "LoadBalancer" }}
   # Specification of on which port the service is enabled
   ports:
   - name: http
-    port: {{ .port }}
-    targetPort: {{ .targetPort }}
+    port: {{ .node.service.port }}
+    targetPort: {{ .node.service.targetPort }}
   selector:
     app: {{ .name }}
 ---

--- a/charts/pega/templates/pega-tier-service.yaml
+++ b/charts/pega/templates/pega-tier-service.yaml
@@ -1,7 +1,7 @@
 {{ if (eq (include "performDeployment" $) "true") }}
 {{ range $index, $dep := .Values.global.tier }}
 {{ if ($dep.service) }}
-{{ template "pega.service" dict "root" $ "name" (printf "pega-%s" $dep.name) "port" $dep.service.port "targetPort" $dep.service.targetPort "serviceType" $dep.service.serviceType }}
+{{ template "pega.service" dict "root" $ "node" $dep "name" (printf "pega-%s" $dep.name) }}
 {{ end }}
 {{ end }}
 {{ end }}


### PR DESCRIPTION
As a user of the Pega Helm charts, I want to be able to specify custom annotations for unique load balancer configurations without needing to extend the charts.

Annotations should be settable for services and ingresses as those are frequently used for for custom configurations.

ElasticSearch provides similar configuration as a model for both service and ingress.

This fixes #63 .
