### PR TITLE
Correct curl command to download helm installer

### DIFF
--- a/docs/prepping-local-system-runbook-linux.md
+++ b/docs/prepping-local-system-runbook-linux.md
@@ -75,11 +75,11 @@ Helm provides a script that you can download and then run to install the latest 
 1. To download the Helm installation script from their Git repository, from
     your home directory enter:
 
-`$ sudo curl
+`$ curl
 https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3 >
-get_helm.sh | bash`
+get_helm.sh`
 
-2. To update the permissions of the file to you can use it for installations,
+2. To update the permissions of the file so you can use it for installations,
     enter:
 
 `$ chmod 700 get_helm.sh`


### PR DESCRIPTION
The intention of this first step is to download the script, which we will execute in step 3. Therefore there is no need to use sudo for it, nor to pipe it to bash.