### PR TITLE
Introduced tier name and kubernetes specific DSS settings 

### DIFF
--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -89,8 +89,6 @@ spec:
         - name: REQUESTOR_PASSIVATION_TIMEOUT
           value: "{{ .node.requestor.passivationTimeSec }}"
 {{- end }}
-        - name: NODE_TIER
-          value: {{ .tierName }}
 {{- if .custom }}
 {{- if .custom.env }}
         # Additional custom env vars
@@ -98,6 +96,9 @@ spec:
 {{- end }}
 {{- end }}
 {{ include "pega.jvmconfig" (dict "node" .node) | indent 8 }}
+        # Tier of the Pega node
+        - name: NODE_TIER
+          value: {{ .tierName }}
         envFrom:
         - configMapRef:
             name: {{ template "pegaEnvironmentConfig" }}

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -86,7 +86,7 @@ spec:
         - name: NODE_TYPE
           value: {{ .nodeType }}
         - name: NODE_TIER
-          value: {{ .name }}
+          value: {{ .tierName }}
         - name: NODE_SETTINGS
           value: Pega-UIEngine/cloud/isNodeAgnosticAdminStudio=true;Pega-IntegrationEngine/EnableRequestorPools=false;
 {{- if .node.requestor }}

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -87,8 +87,6 @@ spec:
           value: {{ .nodeType }}
         - name: NODE_TIER
           value: {{ .tierName }}
-        - name: NODE_SETTINGS
-          value: Pega-UIEngine/cloud/isNodeAgnosticAdminStudio=true;Pega-IntegrationEngine/EnableRequestorPools=false;
 {{- if .node.requestor }}
         - name: REQUESTOR_PASSIVATION_TIMEOUT
           value: "{{ .node.requestor.passivationTimeSec }}"

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -85,6 +85,10 @@ spec:
         # Node type of the Pega nodes for {{ .name }}
         - name: NODE_TYPE
           value: {{ .nodeType }}
+        - name: NODE_TIER
+          value: {{ .name }}
+        - name: NODE_SETTINGS
+          value: Pega-UIEngine/cloud/isNodeAgnosticAdminStudio=true;Pega-IntegrationEngine/EnableRequestorPools=false;
 {{- if .node.requestor }}
         - name: REQUESTOR_PASSIVATION_TIMEOUT
           value: "{{ .node.requestor.passivationTimeSec }}"

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -85,12 +85,12 @@ spec:
         # Node type of the Pega nodes for {{ .name }}
         - name: NODE_TYPE
           value: {{ .nodeType }}
-        - name: NODE_TIER
-          value: {{ .tierName }}
 {{- if .node.requestor }}
         - name: REQUESTOR_PASSIVATION_TIMEOUT
           value: "{{ .node.requestor.passivationTimeSec }}"
 {{- end }}
+        - name: NODE_TIER
+          value: {{ .tierName }}
 {{- if .custom }}
 {{- if .custom.env }}
         # Additional custom env vars

--- a/charts/pega/templates/pega-tier-deployment.yaml
+++ b/charts/pega/templates/pega-tier-deployment.yaml
@@ -30,6 +30,6 @@
 {{ end }}
 
 {{- if or (eq (include "performOnlyDeployment" $) "true") (eq (include "performInstallAndDeployment" $) "true") (eq (include "performUpgradeAndDeployment" $) "true") }}
-{{ template "pega.deployment" dict "root" $ "node" $dep "name" (printf "pega-%s" $dep.name) "kind" $kindName "apiVersion" $apiVer "nodeType" $dep.nodeType "initContainers" $containerWaitList "custom" $dep.custom }}
+{{ template "pega.deployment" dict "root" $ "node" $dep "name" (printf "pega-%s" $dep.name) "tierName" $dep.name "kind" $kindName "apiVersion" $apiVer "nodeType" $dep.nodeType "initContainers" $containerWaitList "custom" $dep.custom }}
 {{- end }}
 {{ end }}


### PR DESCRIPTION
Passed Tier of a node to prpc so that it can be used in admin studio. The NODE_TIER variable is set in setenv.sh file of docker. 
Passed two DSS settings to prpc so that,
1) Requestor pools can be disabled by default in pega, and 
2) Admin studio can display information without node ids