### PR TITLE
Add support for probe configuration Issue/#65

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -243,6 +243,30 @@ Parameter       | Description    | Default value
 `initialHeap`   | This specifies the initial heap size of the JVM.  | `4096m`
 `maxHeap`       | This specifies the maximum heap size of the JVM.  | `7168m`
 
+### Liveness and readiness probes
+
+[Probes are used by Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) as a way to determine if an application is healthy.  They may be configured for liveness to determine if a Pod has entered a broken state, or for readiness to determine if the application is available to be exposed.  Probes may be configured for each tier independently.  If not explicitly configured, default probes will be used.  The following parameters may be used as part of a `livenessProbe` or `readinessProbe` configuration.
+
+Parameter           | Description    | Default value
+---                 | ---            | ---
+`initialDelaySeconds` | Number of seconds after the container has started before liveness or readiness probes are initiated. | `300`
+`timeoutSeconds`      | Number of seconds after which the probe times out. | `20`
+`periodSeconds`       | How often (in seconds) to perform the probe. | `10`
+`successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`
+`failureThreshold`    | When a Pod starts and the probe fails, Kubernetes will try *failureThreshold* times before giving up. | `3`
+
+```yaml
+tier:
+  - name: my-tier
+      livenessProbe:
+        initialDelaySeconds: 60
+        timeoutSeconds: 60
+        failureThreshold: 5
+      readinessProbe:
+        initialDelaySeconds: 400
+        failureThreshold: 30
+```
+
 ### Using a Kubernetes Horizontal Pod Autoscaler (HPA)
 
 You may configure an HPA to scale your tier on a specified metric.  Only tiers that do not use volume claims are scalable with an HPA. Set `hpa.enabled` to `true` in order to deploy an HPA for the tier. For more details, see the [Kubernetes HPA documentation](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/). 

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -255,6 +255,8 @@ Parameter           | Description    | Default value
 `successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`
 `failureThreshold`    | When a Pod starts and the probe fails, Kubernetes will try *failureThreshold* times before giving up. | `3`
 
+Example:
+
 ```yaml
 tier:
   - name: my-tier
@@ -289,6 +291,8 @@ The `deploymentStrategy` can be used to optionally configure the [strategy](http
 ### Environment variables
 
 Pega supports a variety of configuration options for cluster-wide and application settings. In cases when you want to pass a specific environment variable into your deployment on a tier-by-tier basis, you specify a custom `env` block for your tier as shown in the example below.
+
+Example:
 
 ```yaml
 tier:

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -251,7 +251,7 @@ Parameter           | Description    | Default value
 ---                 | ---            | ---
 `initialDelaySeconds` | Number of seconds after the container has started before liveness or readiness probes are initiated. | `300`
 `timeoutSeconds`      | Number of seconds after which the probe times out. | `20`
-`periodSeconds`       | How often (in seconds) to perform the probe. | `10`
+`periodSeconds`       | How often (in seconds) to perform the probe. Some providers such as GCP require this value to be greater than the timeout value. | `30`
 `successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`
 `failureThreshold`    | When a Pod starts and the probe fails, Kubernetes will try *failureThreshold* times before giving up. | `3`
 
@@ -262,7 +262,7 @@ tier:
   - name: my-tier
       livenessProbe:
         initialDelaySeconds: 60
-        timeoutSeconds: 60
+        timeoutSeconds: 30
         failureThreshold: 5
       readinessProbe:
         initialDelaySeconds: 400

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -245,15 +245,15 @@ Parameter       | Description    | Default value
 
 ### Liveness and readiness probes
 
-[Probes are used by Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) as a way to determine if an application is healthy.  They may be configured for liveness to determine if a Pod has entered a broken state, or for readiness to determine if the application is available to be exposed.  Probes may be configured for each tier independently.  If not explicitly configured, default probes will be used.  The following parameters may be used as part of a `livenessProbe` or `readinessProbe` configuration.
+[Probes are used by Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) to determine application health.  Configure a probe for *liveness* to determine if a Pod has entered a broken state; configure it for *readiness* to determine if the application is available to be exposed.  You can configure probes independently for each tier.  If not explicitly configured, default probes are used during the deployment.  Set the following parameters as part of a `livenessProbe` or `readinessProbe` configuration.
 
 Parameter           | Description    | Default value
 ---                 | ---            | ---
 `initialDelaySeconds` | Number of seconds after the container has started before liveness or readiness probes are initiated. | `300`
 `timeoutSeconds`      | Number of seconds after which the probe times out. | `20`
 `periodSeconds`       | How often (in seconds) to perform the probe. Some providers such as GCP require this value to be greater than the timeout value. | `30`
-`successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`
-`failureThreshold`    | When a Pod starts and the probe fails, Kubernetes will try *failureThreshold* times before giving up. | `3`
+`successThreshold`    | Minimum consecutive successes for the probe to be considered successful after it determines a failure. | `1`
+`failureThreshold`    | The number consecutive failures for the pod to be terminated by Kubernetes. | `3`
 
 Example:
 

--- a/charts/pega/templates/_helpers.tpl
+++ b/charts/pega/templates/_helpers.tpl
@@ -130,55 +130,6 @@ until cqlsh -u {{ $cassandraUser | quote }} -p {{ $cassandraPassword | quote }} 
 {{- end }}
 {{- end -}}
 
-{{- define "pega.health.probes" -}}
-# LivenessProbe: indicates whether the container is live, i.e. running.
-# If the LivenessProbe fails, the kubelet will kill the container and
-# the container will be subjected to its RestartPolicy.
-# The default state of Liveness before the initial delay is Success
-livenessProbe:
-  httpGet:
-    # Path that is pinged to check for liveness.
-    path: "/prweb/PRRestService/monitor/pingService/ping"
-    port: 8080
-    scheme: HTTP
-  # Number of seconds after the container has started before liveness or readiness probes are initiated.
-  initialDelaySeconds: 300
-  # Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
-  timeoutSeconds: 20
-  # How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-  periodSeconds: 10
-  # Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.
-  # Must be 1 for liveness. Minimum value is 1.
-  successThreshold: 1
-  # When a Pod starts and the probe fails, Kubernetes will try failureThreshold times before giving up.
-  # Giving up in case of liveness probe means restarting the Pod. In case of readiness probe the
-  # Pod will be marked Unready. Defaults to 3. Minimum value is 1.
-  failureThreshold: 3
-# ReadinessProbe: indicates whether the container is ready to service requests.
-# If the ReadinessProbe fails, the endpoints controller will remove the
-# pod's IP address from the endpoints of all services that match the pod.
-# The default state of Readiness before the initial delay is Failure.
-readinessProbe:
-  httpGet:
-    # Path that is pinged to check for readiness.
-    path: "/prweb/PRRestService/monitor/pingService/ping"
-    port: 8080
-    scheme: HTTP
-  # Number of seconds after the container has started before liveness or readiness probes are initiated.
-  initialDelaySeconds: 300
-  # Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
-  timeoutSeconds: 20
-  # How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-  periodSeconds: 10
-  # Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.
-  # Must be 1 for liveness. Minimum value is 1.
-  successThreshold: 1
-  # When a Pod starts and the probe fails, Kubernetes will try failureThreshold times before giving up.
-  # Giving up in case of liveness probe means restarting the Pod. In case of readiness probe the
-  # Pod will be marked Unready. Defaults to 3. Minimum value is 1.
-  failureThreshold: 3
-{{- end }}
-
 # Evaluate background node types based on cassandra enabled or not(internally or externally)
 {{- define "evaluateBackgroundNodeTypes" }}
   {{- if  eq (include "cassandraEnabled" .) "true" -}}

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -140,7 +140,52 @@ spec:
 {{- end }}
         - name: {{ template "pegaVolumeCredentials" }}
           mountPath: "/opt/pega/secrets"
-{{ include "pega.health.probes" .root | indent 8 }}
+      # LivenessProbe: indicates whether the container is live, i.e. running.
+      # If the LivenessProbe fails, the kubelet will kill the container and
+      # the container will be subjected to its RestartPolicy.
+      # The default state of Liveness before the initial delay is Success
+      livenessProbe:
+        httpGet:
+          # Path that is pinged to check for liveness.
+          path: "/prweb/PRRestService/monitor/pingService/ping"
+          port: 8080
+          scheme: HTTP
+        # Number of seconds after the container has started before liveness or readiness probes are initiated.
+        initialDelaySeconds: 300
+        # Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+        timeoutSeconds: 20
+        # How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+        periodSeconds: 10
+        # Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.
+        # Must be 1 for liveness. Minimum value is 1.
+        successThreshold: 1
+        # When a Pod starts and the probe fails, Kubernetes will try failureThreshold times before giving up.
+        # Giving up in case of liveness probe means restarting the Pod. In case of readiness probe the
+        # Pod will be marked Unready. Defaults to 3. Minimum value is 1.
+        failureThreshold: 3
+      # ReadinessProbe: indicates whether the container is ready to service requests.
+      # If the ReadinessProbe fails, the endpoints controller will remove the
+      # pod's IP address from the endpoints of all services that match the pod.
+      # The default state of Readiness before the initial delay is Failure.
+      readinessProbe:
+        httpGet:
+          # Path that is pinged to check for readiness.
+          path: "/prweb/PRRestService/monitor/pingService/ping"
+          port: 8080
+          scheme: HTTP
+        # Number of seconds after the container has started before liveness or readiness probes are initiated.
+        initialDelaySeconds: 300
+        # Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
+        timeoutSeconds: 20
+        # How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
+        periodSeconds: 10
+        # Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.
+        # Must be 1 for liveness. Minimum value is 1.
+        successThreshold: 1
+        # When a Pod starts and the probe fails, Kubernetes will try failureThreshold times before giving up.
+        # Giving up in case of liveness probe means restarting the Pod. In case of readiness probe the
+        # Pod will be marked Unready. Defaults to 3. Minimum value is 1.
+        failureThreshold: 3
       # Mentions the restart policy to be followed by the pod.  'Always' means that a new pod will always be created irrespective of type of the failure.
       restartPolicy: Always
       # Amount of time in which container has to gracefully shutdown.

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -149,7 +149,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds | default 300 }}
           timeoutSeconds: {{ $livenessProbe.timeoutSeconds | default 20 }}
-          periodSeconds: {{ $livenessProbe.periodSeconds | default 10 }}
+          periodSeconds: {{ $livenessProbe.periodSeconds | default 30 }}
           successThreshold: {{ $livenessProbe.successThreshold | default 1 }}
           failureThreshold: {{ $livenessProbe.failureThreshold | default 3 }}
         # ReadinessProbe: indicates whether the container is ready to service requests.
@@ -161,7 +161,7 @@ spec:
             scheme: HTTP
           initialDelaySeconds: {{ $readinessProbe.initialDelaySeconds | default 300 }}
           timeoutSeconds: {{ $readinessProbe.timeoutSeconds | default 20 }}
-          periodSeconds: {{ $readinessProbe.periodSeconds | default 10 }}
+          periodSeconds: {{ $readinessProbe.periodSeconds | default 30 }}
           successThreshold: {{ $readinessProbe.successThreshold | default 1 }}
           failureThreshold: {{ $readinessProbe.failureThreshold | default 3 }}
       # Mentions the restart policy to be followed by the pod.  'Always' means that a new pod will always be created irrespective of type of the failure.

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -141,51 +141,29 @@ spec:
         - name: {{ template "pegaVolumeCredentials" }}
           mountPath: "/opt/pega/secrets"
       # LivenessProbe: indicates whether the container is live, i.e. running.
-      # If the LivenessProbe fails, the kubelet will kill the container and
-      # the container will be subjected to its RestartPolicy.
-      # The default state of Liveness before the initial delay is Success
+      {{- $livenessProbe := .node.livenessProbe }}
       livenessProbe:
         httpGet:
-          # Path that is pinged to check for liveness.
           path: "/prweb/PRRestService/monitor/pingService/ping"
           port: 8080
           scheme: HTTP
-        # Number of seconds after the container has started before liveness or readiness probes are initiated.
-        initialDelaySeconds: 300
-        # Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
-        timeoutSeconds: 20
-        # How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-        periodSeconds: 10
-        # Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.
-        # Must be 1 for liveness. Minimum value is 1.
-        successThreshold: 1
-        # When a Pod starts and the probe fails, Kubernetes will try failureThreshold times before giving up.
-        # Giving up in case of liveness probe means restarting the Pod. In case of readiness probe the
-        # Pod will be marked Unready. Defaults to 3. Minimum value is 1.
-        failureThreshold: 3
+        initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds | default 300 }}
+        timeoutSeconds: {{ $livenessProbe.timeoutSeconds | default 20 }}
+        periodSeconds: {{ $livenessProbe.periodSeconds | default 10 }}
+        successThreshold: {{ $livenessProbe.successThreshold | default 1 }}
+        failureThreshold: {{ $livenessProbe.failureThreshold | default 3 }}
       # ReadinessProbe: indicates whether the container is ready to service requests.
-      # If the ReadinessProbe fails, the endpoints controller will remove the
-      # pod's IP address from the endpoints of all services that match the pod.
-      # The default state of Readiness before the initial delay is Failure.
+      {{- $readinessProbe := .node.readinessProbe }}
       readinessProbe:
         httpGet:
-          # Path that is pinged to check for readiness.
           path: "/prweb/PRRestService/monitor/pingService/ping"
           port: 8080
           scheme: HTTP
-        # Number of seconds after the container has started before liveness or readiness probes are initiated.
-        initialDelaySeconds: 300
-        # Number of seconds after which the probe times out. Defaults to 1 second. Minimum value is 1.
-        timeoutSeconds: 20
-        # How often (in seconds) to perform the probe. Default to 10 seconds. Minimum value is 1.
-        periodSeconds: 10
-        # Minimum consecutive successes for the probe to be considered successful after having failed. Defaults to 1.
-        # Must be 1 for liveness. Minimum value is 1.
-        successThreshold: 1
-        # When a Pod starts and the probe fails, Kubernetes will try failureThreshold times before giving up.
-        # Giving up in case of liveness probe means restarting the Pod. In case of readiness probe the
-        # Pod will be marked Unready. Defaults to 3. Minimum value is 1.
-        failureThreshold: 3
+        initialDelaySeconds: {{ $readinessProbe.initialDelaySeconds | default 300 }}
+        timeoutSeconds: {{ $readinessProbe.timeoutSeconds | default 20 }}
+        periodSeconds: {{ $readinessProbe.periodSeconds | default 10 }}
+        successThreshold: {{ $readinessProbe.successThreshold | default 1 }}
+        failureThreshold: {{ $readinessProbe.failureThreshold | default 3 }}
       # Mentions the restart policy to be followed by the pod.  'Always' means that a new pod will always be created irrespective of type of the failure.
       restartPolicy: Always
       # Amount of time in which container has to gracefully shutdown.

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -140,30 +140,30 @@ spec:
 {{- end }}
         - name: {{ template "pegaVolumeCredentials" }}
           mountPath: "/opt/pega/secrets"
-      # LivenessProbe: indicates whether the container is live, i.e. running.
-      {{- $livenessProbe := .node.livenessProbe }}
-      livenessProbe:
-        httpGet:
-          path: "/prweb/PRRestService/monitor/pingService/ping"
-          port: 8080
-          scheme: HTTP
-        initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds | default 300 }}
-        timeoutSeconds: {{ $livenessProbe.timeoutSeconds | default 20 }}
-        periodSeconds: {{ $livenessProbe.periodSeconds | default 10 }}
-        successThreshold: {{ $livenessProbe.successThreshold | default 1 }}
-        failureThreshold: {{ $livenessProbe.failureThreshold | default 3 }}
-      # ReadinessProbe: indicates whether the container is ready to service requests.
-      {{- $readinessProbe := .node.readinessProbe }}
-      readinessProbe:
-        httpGet:
-          path: "/prweb/PRRestService/monitor/pingService/ping"
-          port: 8080
-          scheme: HTTP
-        initialDelaySeconds: {{ $readinessProbe.initialDelaySeconds | default 300 }}
-        timeoutSeconds: {{ $readinessProbe.timeoutSeconds | default 20 }}
-        periodSeconds: {{ $readinessProbe.periodSeconds | default 10 }}
-        successThreshold: {{ $readinessProbe.successThreshold | default 1 }}
-        failureThreshold: {{ $readinessProbe.failureThreshold | default 3 }}
+        # LivenessProbe: indicates whether the container is live, i.e. running.
+        {{- $livenessProbe := .node.livenessProbe }}
+        livenessProbe:
+          httpGet:
+            path: "/prweb/PRRestService/monitor/pingService/ping"
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds | default 300 }}
+          timeoutSeconds: {{ $livenessProbe.timeoutSeconds | default 20 }}
+          periodSeconds: {{ $livenessProbe.periodSeconds | default 10 }}
+          successThreshold: {{ $livenessProbe.successThreshold | default 1 }}
+          failureThreshold: {{ $livenessProbe.failureThreshold | default 3 }}
+        # ReadinessProbe: indicates whether the container is ready to service requests.
+        {{- $readinessProbe := .node.readinessProbe }}
+        readinessProbe:
+          httpGet:
+            path: "/prweb/PRRestService/monitor/pingService/ping"
+            port: 8080
+            scheme: HTTP
+          initialDelaySeconds: {{ $readinessProbe.initialDelaySeconds | default 300 }}
+          timeoutSeconds: {{ $readinessProbe.timeoutSeconds | default 20 }}
+          periodSeconds: {{ $readinessProbe.periodSeconds | default 10 }}
+          successThreshold: {{ $readinessProbe.successThreshold | default 1 }}
+          failureThreshold: {{ $readinessProbe.failureThreshold | default 3 }}
       # Mentions the restart policy to be followed by the pod.  'Always' means that a new pod will always be created irrespective of type of the failure.
       restartPolicy: Always
       # Amount of time in which container has to gracefully shutdown.

--- a/terratest/src/test/deployment_utility.go
+++ b/terratest/src/test/deployment_utility.go
@@ -144,7 +144,7 @@ func VerifyDeployment(t *testing.T, pod *k8score.PodSpec, expectedSpec pegaDeplo
 
 	require.Equal(t, pod.Containers[0].LivenessProbe.InitialDelaySeconds, int32(300))
 	require.Equal(t, pod.Containers[0].LivenessProbe.TimeoutSeconds, int32(20))
-	require.Equal(t, pod.Containers[0].LivenessProbe.PeriodSeconds, int32(10))
+	require.Equal(t, pod.Containers[0].LivenessProbe.PeriodSeconds, int32(30))
 	require.Equal(t, pod.Containers[0].LivenessProbe.SuccessThreshold, int32(1))
 	require.Equal(t, pod.Containers[0].LivenessProbe.FailureThreshold, int32(3))
 	require.Equal(t, pod.Containers[0].LivenessProbe.HTTPGet.Path, "/prweb/PRRestService/monitor/pingService/ping")
@@ -153,7 +153,7 @@ func VerifyDeployment(t *testing.T, pod *k8score.PodSpec, expectedSpec pegaDeplo
 
 	require.Equal(t, pod.Containers[0].ReadinessProbe.InitialDelaySeconds, int32(300))
 	require.Equal(t, pod.Containers[0].ReadinessProbe.TimeoutSeconds, int32(20))
-	require.Equal(t, pod.Containers[0].ReadinessProbe.PeriodSeconds, int32(10))
+	require.Equal(t, pod.Containers[0].ReadinessProbe.PeriodSeconds, int32(30))
 	require.Equal(t, pod.Containers[0].ReadinessProbe.SuccessThreshold, int32(1))
 	require.Equal(t, pod.Containers[0].ReadinessProbe.FailureThreshold, int32(3))
 	require.Equal(t, pod.Containers[0].ReadinessProbe.HTTPGet.Path, "/prweb/PRRestService/monitor/pingService/ping")


### PR DESCRIPTION
### Liveness and readiness probes

[Probes are used by Kubernetes](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/) as a way to determine if an application is healthy.  They may be configured for liveness to determine if a Pod has entered a broken state, or for readiness to determine if the application is available to be exposed.  Probes may be configured for each tier independently.  If not explicitly configured, default probes will be used.  The following parameters may be used as part of a `livenessProbe` or `readinessProbe` configuration.

Parameter           | Description    | Default value
---                 | ---            | ---
`initialDelaySeconds` | Number of seconds after the container has started before liveness or readiness probes are initiated. | `300`
`timeoutSeconds`      | Number of seconds after which the probe times out. | `20`
`periodSeconds`       | How often (in seconds) to perform the probe. | `30`
`successThreshold`    | Minimum consecutive successes for the probe to be considered successful after having failed. | `1`
`failureThreshold`    | When a Pod starts and the probe fails, Kubernetes will try *failureThreshold* times before giving up. | `3`

Example:

```yaml
tier:
  - name: my-tier
      livenessProbe:
        initialDelaySeconds: 60
        timeoutSeconds: 30
        failureThreshold: 5
      readinessProbe:
        initialDelaySeconds: 400
        failureThreshold: 30
```

This closes #65 