### PR TITLE
Upgrades traefik addon dependency to 1.77.3

### DIFF
--- a/charts/addons/Chart.yaml
+++ b/charts/addons/Chart.yaml
@@ -3,4 +3,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: addons
-version: 1.2.0
+version: 1.2.1

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: traefik
-  version: "1.77.1"
+  version: "1.77.3"
   repository: https://kubernetes-charts.storage.googleapis.com
   condition: traefik.enabled
 - name: aws-alb-ingress-controller

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -16,6 +16,11 @@ traefik:
     enabled: false
   rbac:
     enabled: true
+  # If Kubernetes namespace selection is defined and the (one) selected namespace is the release
+  # namespace, a Role and RoleBinding will be used in lieu of a ClusterRole and ClusterRoleBinding 
+  # kubernetes:
+  #   namespaces:
+  #   - default
   service:
     nodePorts:
       # NodePorts for traefik service.

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -17,7 +17,7 @@ traefik:
   rbac:
     enabled: true
   # If Kubernetes namespace selection is defined and the (one) selected namespace is the release
-  # namespace, a Role and RoleBinding will be used in lieu of a ClusterRole and ClusterRoleBinding 
+  # namespace, a Role and RoleBinding will be used in lieu of a ClusterRole and ClusterRoleBinding
   # kubernetes:
   #   namespaces:
   #   - default

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -18,7 +18,8 @@ traefik:
     enabled: true
   # If Kubernetes namespace selection is defined and the (one) selected namespace is the release
   # namespace, a Role and RoleBinding will be used in lieu of a ClusterRole and ClusterRoleBinding. 
-  # Use it to have isolated traefik deployment for each Pega deployment in a namespace. Only single namepsace value can be provided.
+  # Use it to have isolated traefik deployment for each Pega deployment in a namespace. 
+  # Only single namepsace value can be provided.
   # kubernetes:
   #   namespaces:
   #   - default

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -17,7 +17,8 @@ traefik:
   rbac:
     enabled: true
   # If Kubernetes namespace selection is defined and the (one) selected namespace is the release
-  # namespace, a Role and RoleBinding will be used in lieu of a ClusterRole and ClusterRoleBinding
+  # namespace, a Role and RoleBinding will be used in lieu of a ClusterRole and ClusterRoleBinding. 
+  # Use it to have isolated traefik deployment for each Pega deployment in a namespace. Only single namepsace value can be provided.
   # kubernetes:
   #   namespaces:
   #   - default


### PR DESCRIPTION
This addresses #81, and will allow the Traefik addon to use `Role` and `RoleBinding` rather than `ClusterRole` and `ClusterRoleBinding` when desired.