### PR TITLE
adding default value to usePrivateIP

### DIFF
--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -129,6 +129,8 @@ ingress-azure:
     resourceGroup: <RESOURCE_GROUP_NAME>
     # Name of the Application Gateway you created.
     name: <APPLICATION_GATEWAY_NAME>
+    # To expose the ingress endpoint within the Virtual Network, use privateIP.This setting is not required for Internet exposed ingress, hence disabling.
+    usePrivateIP: false
   # Authentication using which ingress controller authenticates with Azure Resource Manager.
   armAuth:
     # There are two supported authentication methods:


### PR DESCRIPTION
usePrivateIP doesn't have a default value because of which we are facing issue in deployment, commented on the PR - https://github.com/Azure/application-gateway-kubernetes-ingress/pull/722, where they claim it as issue fixed.