### PR TITLE
ISSUE-125: Add option to set CATALINA_OPTS, with default values

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -103,7 +103,7 @@ It is standard practice to have separate schemas for your rules and data.  You m
  
  Example:
  
- ```yaml
+```yaml
 jdbc:
   ...
   rulesSchema: "rules"
@@ -119,7 +119,7 @@ When using a private registry that requires a username and password, specify the
 
 Example:
 
- ```yaml
+```yaml
 docker:
   registry:
     url: "YOUR_DOCKER_REGISTRY"
@@ -341,6 +341,21 @@ Parameter       | Description    | Default value
 `memLimit`      | Memory limit for pods in the current tier. | `8Gi`
 `initialHeap`   | This specifies the initial heap size of the JVM.  | `4096m`
 `maxHeap`       | This specifies the maximum heap size of the JVM.  | `7168m`
+
+### JVM Arguments
+
+You can optionally pass in JVM arguments to Tomcat.  Depending on the parameter used the arguments will be placed into `JAVA_OPTS` or `CATALINA_OPTS` environmental variables.
+
+Best-practice arguments for heap tuning and garbage collection are included by default in CATALINA_OPTS.  Specifying a value for this parameter will replace the default values with your organization's preferred arguments.  Ensure that any default values you wish to keep are also included in `additionalCatalinaOpts`.
+
+Example:
+
+```yaml
+tier:
+  - name: my-tier
+    javaOpts: ""
+    additionalCatalinaOpts: "-Dcustom.argument"
+```
 
 ### Liveness and readiness probes
 

--- a/charts/pega/templates/_helpers.tpl
+++ b/charts/pega/templates/_helpers.tpl
@@ -122,6 +122,12 @@ until cqlsh -u {{ $cassandraUser | quote }} -p {{ $cassandraPassword | quote }} 
 # Additional JVM arguments
 - name: JAVA_OPTS
   value: "{{ .node.javaOpts }}"
+- name: ADDITIONAL_CATALINA_OPTS
+{{- if .node.additionalCatalinaOpts }}
+  value: "{{ .node.additionalCatalinaOpts }}"
+{{- else }}
+  value: "-XX:MetaspaceSize=512M -XX:MaxMetaspaceSize=1G -XX:ReservedCodeCacheSize=512M -XX:+DisableExplicitGC -XX:+ParallelRefProcEnabled -XX:+UseStringDeduplication -Djava.awt.headless=true -Xlog:gc*,gc+heap=debug,gc+humongous=debug:file=/usr/local/tomcat/logs/gc.log:tags,uptime,pid,level,time"
+{{- end }}
 # Initial JVM heap size, equivalent to -Xms
 - name: INITIAL_HEAP
 {{- if .node.initialHeap }}


### PR DESCRIPTION
Updated helpers to set ADDITIONAL_CATALINA_OPTS based on additionalCatalinaOpts. Updated README.md with appropriate instructions.

Default value of CATALINA_OPTS is set to recommended values for GC and heap (metaspace, code cache size, etc).

I implemented this as CATALINA_OPTS instead of JAVA_OPTS since JAVA_OPTS applies to the stop command and forked processes like Kafka.  I also fixed inconsistencies with indentation in a couple of ```yaml blocks in the README.md that was breaking the preview in Macdown...other editors might not mind.

This change needs to be paired with a small update to setenv.sh in the docker image.

[setenv.sh.zip](https://github.com/pegasystems/pega-helm-charts/files/4441076/setenv.sh.zip)


This also addresses https://github.com/pegasystems/docker-pega-web-ready/issues/37

