### PR TITLE
Custom Annotations

### DIFF
--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -31,8 +31,8 @@ spec:
       annotations:
         config-check: {{ include (print .root.Template.BasePath "/pega-environment-config.yaml") .root | sha256sum }}
         revision: "{{ .root.Release.Revision }}"
-{{- if (.Values.kubernetes.safeToEvict) }}
-        cluster-autoscaler.kubernetes.io/safe-to-evict: "{{.Values.kubernetes.safeToEvict}}"
+{{- if (.Values.global.kubernetes.safeToEvict) }}
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "{{.Values.global.kubernetes.safeToEvict}}"
 {{- end }}
     spec:
       volumes:

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -31,7 +31,9 @@ spec:
       annotations:
         config-check: {{ include (print .root.Template.BasePath "/pega-environment-config.yaml") .root | sha256sum }}
         revision: "{{ .root.Release.Revision }}"
+{{- if (.Values.kubernetes.safeToEvict) }}
         cluster-autoscaler.kubernetes.io/safe-to-evict: "{{.Values.kubernetes.safeToEvict}}"
+{{- end }}
     spec:
       volumes:
       # Volume used to mount config files.

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -9,7 +9,6 @@ metadata:
     component: Pega
 spec:
   # Replicas specify the number of copies for {{ .name }}
-  # Replicas specify the number of copies for {{ .name }}
   replicas: {{ .node.replicas }}
 {{- if (eq .kind "Deployment") }}
   progressDeadlineSeconds: 2147483647
@@ -32,7 +31,7 @@ spec:
       annotations:
         config-check: {{ include (print .root.Template.BasePath "/pega-environment-config.yaml") .root | sha256sum }}
         revision: "{{ .root.Release.Revision }}"
-		cluster-autoscaler.kubernetes.io/safe-to-evict: "{{.Values.kubernetes.safeToEvict}}"
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "{{.Values.kubernetes.safeToEvict}}"
     spec:
       volumes:
       # Volume used to mount config files.

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -9,6 +9,7 @@ metadata:
     component: Pega
 spec:
   # Replicas specify the number of copies for {{ .name }}
+  # Replicas specify the number of copies for {{ .name }}
   replicas: {{ .node.replicas }}
 {{- if (eq .kind "Deployment") }}
   progressDeadlineSeconds: 2147483647
@@ -31,6 +32,7 @@ spec:
       annotations:
         config-check: {{ include (print .root.Template.BasePath "/pega-environment-config.yaml") .root | sha256sum }}
         revision: "{{ .root.Release.Revision }}"
+		cluster-autoscaler.kubernetes.io/safe-to-evict: "{{.Values.kubernetes.safeToEvict}}"
     spec:
       volumes:
       # Volume used to mount config files.

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -31,10 +31,10 @@ spec:
       annotations:
 {{- if .node.podAnnotations }}
 {{ toYaml .node.podAnnotations | indent 8 }}
-{{- else }}
+{{- end }}
         config-check: {{ include (print .root.Template.BasePath "/pega-environment-config.yaml") .root | sha256sum }}
         revision: "{{ .root.Release.Revision }}"
-{{- end }}
+
     spec:
       volumes:
       # Volume used to mount config files.

--- a/charts/pega/templates/_pega-eks-ingress.tpl
+++ b/charts/pega/templates/_pega-eks-ingress.tpl
@@ -25,12 +25,16 @@ metadata:
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
     {{ end }}
     {{ end }}
-    # override the default scheme internal as ALB should be internet-facing 
+    {{- if .node.ingress.annotations }}
+    {{ toYaml .node.ingress.annotations }}
+    {{- else }}
+    # override the default scheme internal as ALB should be internet-facing
     alb.ingress.kubernetes.io/scheme: internet-facing
-    # enable sticky sessions on target group
-    alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds={{ include "lbSessionCookieStickiness" . }}
     # set to ip mode to route traffic directly to the pods ip
     alb.ingress.kubernetes.io/target-type: ip
+    {{- end }}
+    # enable sticky sessions on target group
+    alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds={{ include "lbSessionCookieStickiness" . }}
 spec:
   rules:
   {{ if (.node.service.domain) }}

--- a/charts/pega/templates/_pega-eks-ingress.tpl
+++ b/charts/pega/templates/_pega-eks-ingress.tpl
@@ -8,33 +8,35 @@ metadata:
   annotations:
     # Ingress class used is 'alb'
     kubernetes.io/ingress.class: alb
-    {{ if (.node.service.domain) }}
+{{ if (.node.service.domain) }}
     {{ template "eksHttpsAnnotationSnippet" }}
-    {{ else }}
-    {{- if (.node.ingress) }}
-    {{- if (.node.ingress.tls) }}
-    {{- if (eq .node.ingress.tls.enabled true) }}
+{{ else }}
+{{- if (.node.ingress) }}
+{{- if (.node.ingress.tls) }}
+{{- if (eq .node.ingress.tls.enabled true) }}
     {{ template "eksHttpsAnnotationSnippet" }}
-    {{ if (.node.ingress.tls.ssl_annotation) }}
-    {{ toYaml .node.ingress.tls.ssl_annotation }}
-    {{ end }}
-    {{ end }}
-    {{ end }}
-    {{ else }}
+{{ if (.node.ingress.tls.ssl_annotation) }}
+{{ toYaml .node.ingress.tls.ssl_annotation | indent 4 }}
+{{ end }}
+{{ end }}
+{{ end }}
+{{ else }}
     # specifies the ports that ALB used to listen on
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTP": 80}]'
-    {{ end }}
-    {{ end }}
-    {{- if .node.ingress.annotations }}
-    {{ toYaml .node.ingress.annotations }}
-    {{- else }}
+{{ end }}
+{{ end }}
+{{- if .node.ingress.annotations }}
+{{ toYaml .node.ingress.annotations | indent 4 }}
+{{- else }}
     # override the default scheme internal as ALB should be internet-facing
     alb.ingress.kubernetes.io/scheme: internet-facing
     # set to ip mode to route traffic directly to the pods ip
     alb.ingress.kubernetes.io/target-type: ip
-    {{- end }}
+{{- end }}
+{{- if not (and (.node.ingress.annotations) ( .node.ingress.annotations | quote | regexFind "alb.ingress.kubernetes.io/target-group-attributes:" ) ) }}
     # enable sticky sessions on target group
     alb.ingress.kubernetes.io/target-group-attributes: stickiness.enabled=true,stickiness.lb_cookie.duration_seconds={{ include "lbSessionCookieStickiness" . }}
+{{- end }}
 spec:
   rules:
   {{ if (.node.service.domain) }}

--- a/charts/pega/values-large.yaml
+++ b/charts/pega/values-large.yaml
@@ -6,10 +6,6 @@ global:
 
   # Enter your Kubernetes provider.
   provider: "YOUR_KUBERNETES_PROVIDER"
-  
-  # Safe to evict during auto scaling
-  kubernetes:
-    safeToEvict: "true"
 
   # Deploy Pega nodes
   actions:

--- a/charts/pega/values-large.yaml
+++ b/charts/pega/values-large.yaml
@@ -6,6 +6,10 @@ global:
 
   # Enter your Kubernetes provider.
   provider: "YOUR_KUBERNETES_PROVIDER"
+  
+  # Safe to evict during auto scaling
+  kubernetes:
+    safeToEvict: "true"
 
   # Deploy Pega nodes
   actions:

--- a/charts/pega/values-minimal.yaml
+++ b/charts/pega/values-minimal.yaml
@@ -6,6 +6,10 @@ global:
 
   # Enter your Kubernetes provider.
   provider: "k8s"
+  
+  # Safe to evict during auto scaling
+  kubernetes:
+    safeToEvict: "true"
 
   # Deploy Pega nodes
   actions:

--- a/charts/pega/values-minimal.yaml
+++ b/charts/pega/values-minimal.yaml
@@ -6,10 +6,6 @@ global:
 
   # Enter your Kubernetes provider.
   provider: "k8s"
-  
-  # Safe to evict during auto scaling
-  kubernetes:
-    safeToEvict: "true"
 
   # Deploy Pega nodes
   actions:

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -5,10 +5,6 @@ global:
 
   # Enter your Kubernetes provider.
   provider: "YOUR_KUBERNETES_PROVIDER"
-  
-  # Safe to evict during auto scaling
-  kubernetes:
-    safeToEvict: "true"
 
   # Deploy Pega nodes
   actions:

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -5,6 +5,9 @@ global:
 
   # Enter your Kubernetes provider.
   provider: "YOUR_KUBERNETES_PROVIDER"
+  
+  kubernetes:
+    safeToEvict: "true"
 
   # Deploy Pega nodes
   actions:

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -6,6 +6,7 @@ global:
   # Enter your Kubernetes provider.
   provider: "YOUR_KUBERNETES_PROVIDER"
   
+  # Safe to evict during auto scaling
   kubernetes:
     safeToEvict: "true"
 


### PR DESCRIPTION
This change for internal pega helm usage in EKS cluster to evict a pod during autoscaling.
The default has been set to true in-line with the behaviour had the annotation not been set.