### PR TITLE
ISSUE-135: Overriding health checks for web and stream load balancers

### DIFF
--- a/charts/pega/templates/pega-gke-backend-config.yaml
+++ b/charts/pega/templates/pega-gke-backend-config.yaml
@@ -10,4 +10,12 @@ spec:
   sessionAffinity:
     affinityType: "GENERATED_COOKIE"
     affinityCookieTtlSec: {{ template "lbSessionCookieStickiness" }}
+  healthCheck:
+    checkIntervalSec: 5
+    healthyThreshold: 1
+    port: 8080
+    requestPath: /prweb/PRRestService/monitor/pingService/ping
+    timeoutSec: 5
+    type: HTTP
+    unhealthyThreshold: 2
 {{ end }}


### PR DESCRIPTION
This PR is to address [ISSUE-135](https://github.com/pegasystems/pega-helm-charts/issues/135)
In GKE, overriding health check of load balancer (specifically Stream) to use Platform ping service. This fix require GKE version to be 1.17.6-gke.11 or higher. Ref. [ingress-features](https://cloud.google.com/kubernetes-engine/docs/how-to/ingress-features).
This change does not introduce regression if deployed on lower versions than 1.17.6-gke.11.