### PR TITLE
Issue 142 - Upgrade addons chart version to be compatible with k8s 1.16

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,3 +97,4 @@ deploy:
     on:
       all_branches: true
       tags: true 
+ 

--- a/.travis.yml
+++ b/.travis.yml
@@ -96,5 +96,4 @@ deploy:
     skip_cleanup: true
     on:
       all_branches: true
-      tags: true 
- 
+      tags: true

--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,8 @@ dependencies:
 	helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com/
 	helm repo add stable https://kubernetes-charts.storage.googleapis.com
 	helm repo add application-gateway-kubernetes-ingress https://appgwingress.blob.core.windows.net/ingress-azure-helm-package/
+	helm repo add kiwigrid https://kiwigrid.github.io
+	helm repo add elastic https://helm.elastic.co
 	helm repo list	
 	helm dependency update ./charts/pega/
 	helm dependency update ./charts/addons/ 

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -24,6 +24,6 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: metrics-server.enabled
 - name: ingress-azure
-  version: "1.2.0-rc3"
+  version: "1.2.0"
   repository: https://appgwingress.blob.core.windows.net/ingress-azure-helm-package/
   condition: ingress-azure.enabled

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -4,7 +4,7 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com
   condition: traefik.enabled
 - name: aws-alb-ingress-controller
-  version: "0.1.10"
+  version: "1.0.2"
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: aws-alb-ingress-controller.enabled
 - name: elasticsearch

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -24,6 +24,6 @@ dependencies:
   repository: https://kubernetes-charts.storage.googleapis.com/
   condition: metrics-server.enabled
 - name: ingress-azure
-  version: "1.0.0"
+  version: "1.2.0-rc3"
   repository: https://appgwingress.blob.core.windows.net/ingress-azure-helm-package/
   condition: ingress-azure.enabled

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -8,16 +8,16 @@ dependencies:
   repository: https://kubernetes-charts-incubator.storage.googleapis.com/
   condition: aws-alb-ingress-controller.enabled
 - name: elasticsearch
-  version: "1.15.1"
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: "7.8.1"
+  repository: https://helm.elastic.co/
   condition: elasticsearch.enabled
 - name: fluentd-elasticsearch
-  version: "1.5.0"
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: "9.6.0"
+  repository: https://kiwigrid.github.io/
   condition: fluentd-elasticsearch.enabled
 - name: kibana
-  version: "1.1.0"
-  repository: https://kubernetes-charts.storage.googleapis.com/
+  version: "7.8.1"
+  repository: https://helm.elastic.co/
   condition: kibana.enabled
 - name: metrics-server
   version: "2.8.4"

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -65,40 +65,44 @@ deploy_efk: &deploy_efk true
 elasticsearch:
   enabled: *deploy_efk
   # Set any additional elastic search parameters. These values will be used by elasticsearch helm chart.
-  # See https://github.com/helm/charts/tree/master/stable/elasticsearch/values.yaml
+  # See https://github.com/elastic/helm-charts/blob/master/elasticsearch/values.yaml
   #
-  # If you need to change this value then you will also need to replace the same
-  # part of the value within the following properties further below:
-  #
-  #   kibana.files.kibana.yml.elasticsearch.url
-  #   fluentd-elasticsearch.elasticsearch.host
-  #
-  fullnameOverride: "elastic-search"
+  antiAffinity: soft
+  esJavaOpts: "-Xmx512m -Xms512m"
+  # Allocate smaller chunks of memory per pod.
+  resources:
+    requests:
+      cpu: "100m"
+      memory: "512M"
+    limits:
+      cpu: "1000m"
+      memory: "1Gi"
+  # Request smaller persistent volumes.
+  volumeClaimTemplate:
+    accessModes: [ "ReadWriteOnce" ]
+    storageClassName: "standard"
+    resources:
+      requests:
+        storage: 10Gi
 
 kibana:
   enabled: *deploy_efk
   # Set any additional kibana parameters. These values will be used by Kibana's helm chart.
-  # See https://github.com/helm/charts/tree/master/stable/kibana/values.yaml
-  files:
-    kibana.yml:
-      elasticsearch.url: http://elastic-search-client:9200
-  service:
-    externalPort: 80
+  # See https://github.com/elastic/helm-charts/blob/master/kibana/values.yaml
+  elasticsearchHosts: "http://elasticsearch-master:9200"
   ingress:
     # If enabled is set to "true", an ingress is created to access kibana.
     enabled: true
     # Enter the domain name to access kibana via a load balancer.
     hosts:
-      - "YOUR_WEB.KIBANA.EXAMPLE.COM"
+      - "mykibana.dev.pega.io"
 
 fluentd-elasticsearch:
   enabled: *deploy_efk
   # Set any additional fluentd-elasticsearch parameters. These values will be used by fluentd-elasticsearch's helm chart.
-  # See https://github.com/helm/charts/tree/master/stable/fluentd-elasticsearch/values.yaml
+  # See https://github.com/kiwigrid/helm-charts/blob/master/charts/fluentd-elasticsearch/values.yaml
   elasticsearch:
-    host: elastic-search-client
-    buffer_chunk_limit: 250M
-    buffer_queue_limit: 30
+    hosts: ["elasticsearch-master:9200"]
 
 # Configure a metrics-server tool for the deployment by following the guidelines specific to each provider:
 # EKS, open-source Kubernetes, Openshift - set this to true.
@@ -122,7 +126,7 @@ metrics-server:
 # Application Gateway config based on the status of the Kubernetes cluster. For details, see
 # (https://docs.microsoft.com/en-us/azure/application-gateway/ingress-controller-install-existing#azure-resource-manager-authentication).
 ingress-azure:
-  enabled: true
+  enabled: false
   # Add required details about the Application Gateway you created.
   appgw:
     # Subscription ID of your Azure subscription.

--- a/terratest/src/test/addons/efk_test.go
+++ b/terratest/src/test/addons/efk_test.go
@@ -3,15 +3,13 @@ package addons
 import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/apps/v1beta2"
-	v1 "k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
-	"test/common"
 	"testing"
 )
 
 func TestShouldNotContainDeploy_EFKIfDisabled(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
+	helmChartParser := NewHelmConfigParser(
+		NewHelmTest(t, helmChartRelativePath, map[string]string{
 			"elasticsearch.enabled":         "false",
 			"kibana.enabled":                "false",
 			"fluentd-elasticsearch.enabled": "false",
@@ -19,15 +17,16 @@ func TestShouldNotContainDeploy_EFKIfDisabled(t *testing.T) {
 	)
 
 	for _, i := range deployEfkResources {
-		require.False(t, helmChartParser.Contains(common.SearchResourceOption{
+		require.False(t, helmChartParser.Contains(SearchResourceOption{
 			Name: i.Name,
 			Kind: i.Kind,
 		}))
 	}
 }
+
 func TestShouldDeploy_EFKContainAllResourcesIfEnabled(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
+	helmChartParser := NewHelmConfigParser(
+		NewHelmTest(t, helmChartRelativePath, map[string]string{
 			"elasticsearch.enabled":         "true",
 			"kibana.enabled":                "true",
 			"fluentd-elasticsearch.enabled": "true",
@@ -35,89 +34,44 @@ func TestShouldDeploy_EFKContainAllResourcesIfEnabled(t *testing.T) {
 	)
 
 	for _, i := range deployEfkResources {
-		require.True(t, helmChartParser.Contains(common.SearchResourceOption{
+		require.True(t, helmChartParser.Contains(SearchResourceOption{
 			Name: i.Name,
 			Kind: i.Kind,
 		}))
 	}
 }
 
-func Test_shouldBeFullnameOverrideForElasticsearch(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"elasticsearch.enabled": "true",
-		}),
-	)
-	require.True(t, helmChartParser.Contains(common.SearchResourceOption{
-		Name: "elastic-search",
-		Kind: "ConfigMap",
-	}))
-}
-
-func Test_shouldBeElasticSearchUrlForKibana(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"kibana.enabled": "true",
-			"kibana.files.kibana.yml.elasticsearch.url": "http://elastic-search-client:9200",
-		}),
-	)
-
-	var configmap *v1.ConfigMap
-	helmChartParser.Find(common.SearchResourceOption{
-		Name: "release-name-kibana",
-		Kind: "ConfigMap",
-	}, &configmap)
-
-	require.Contains(t, configmap.Data["kibana.yml"], "http://elastic-search-client:9200")
-}
-func Test_shouldBeServiceExternalPortForKibana(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"kibana.enabled":              "true",
-			"kibana.service.externalPort": "80",
-		}),
-	)
-
-	var service *v1.Service
-	helmChartParser.Find(common.SearchResourceOption{
-		Name: "release-name-kibana",
-		Kind: "Service",
-	}, &service)
-
-	require.Equal(t, int32(80), service.Spec.Ports[0].Port)
-}
-
 func Test_shouldBeIngressEnabledForKibana(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
+	helmChartParser := NewHelmConfigParser(
+		NewHelmTest(t, helmChartRelativePath, map[string]string{
 			"kibana.enabled":         "true",
 			"kibana.ingress.enabled": "true",
 		}),
 	)
 
-	require.True(t, helmChartParser.Contains(common.SearchResourceOption{
-		Name: "release-name-kibana",
+	require.True(t, helmChartParser.Contains(SearchResourceOption{
+		Name: "pega-kibana",
 		Kind: "Ingress",
 	}))
 }
 
 func Test_shouldBeIngressDisabledForKibana(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
+	helmChartParser := NewHelmConfigParser(
+		NewHelmTest(t, helmChartRelativePath, map[string]string{
 			"kibana.enabled":         "true",
 			"kibana.ingress.enabled": "false",
 		}),
 	)
 
-	require.False(t, helmChartParser.Contains(common.SearchResourceOption{
-		Name: "release-name-kibana",
+	require.False(t, helmChartParser.Contains(SearchResourceOption{
+		Name: "pega-kibana",
 		Kind: "Ingress",
 	}))
 }
 
 func Test_shouldBeHostForIngressKibana(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
+	helmChartParser := NewHelmConfigParser(
+		NewHelmTest(t, helmChartRelativePath, map[string]string{
 			"kibana.enabled":         "true",
 			"kibana.ingress.enabled": "true",
 			"kibana.ingress.hosts":   "{YOUR_WEB.KIBANA.EXAMPLE.COM}",
@@ -125,8 +79,8 @@ func Test_shouldBeHostForIngressKibana(t *testing.T) {
 	)
 
 	var ingress *v1beta1.Ingress
-	helmChartParser.Find(common.SearchResourceOption{
-		Name: "release-name-kibana",
+	helmChartParser.Find(SearchResourceOption{
+		Name: "pega-kibana",
 		Kind: "Ingress",
 	}, &ingress)
 
@@ -134,123 +88,61 @@ func Test_shouldBeHostForIngressKibana(t *testing.T) {
 
 }
 func Test_shouldBeHostForElasticsearch(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
+	helmChartParser := NewHelmConfigParser(
+		NewHelmTest(t, helmChartRelativePath, map[string]string{
 			"fluentd-elasticsearch.enabled": "true",
-			"elasticsearch.host":            "elastic-search-client",
+			"fluentd-elasticsearch.elasticsearch.host": "elasticsearch-master:9200",
 		}),
 	)
 
 	var daemon *v1beta2.DaemonSet
-	helmChartParser.Find(common.SearchResourceOption{
-		Name: "release-name-fluentd-elasticsearch",
+	helmChartParser.Find(SearchResourceOption{
+		Name: "pega-fluentd-elasticsearch",
 		Kind: "DaemonSet",
 	}, &daemon)
 
-	require.Equal(t, "elastic-search-client", daemon.Spec.Template.Spec.Containers[0].Env[1].Value)
+	require.Equal(t, "elasticsearch-master:9200", daemon.Spec.Template.Spec.Containers[0].Env[1].Value)
 }
 
-func Test_shouldBeBufferChunkLimitForElasticsearch(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"fluentd-elasticsearch.enabled":    "true",
-			"elasticsearch.buffer_chunk_limit": "250M",
-		}),
-	)
-
-	var daemon *v1beta2.DaemonSet
-	helmChartParser.Find(common.SearchResourceOption{
-		Name: "release-name-fluentd-elasticsearch",
-		Kind: "DaemonSet",
-	}, &daemon)
-
-	require.Equal(t, "250M", daemon.Spec.Template.Spec.Containers[0].Env[4].Value)
-}
-
-func Test_shouldBeBufferQueueLimitForElasticsearch(t *testing.T) {
-	helmChartParser := common.NewHelmConfigParser(
-		common.NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"fluentd-elasticsearch.enabled":    "true",
-			"elasticsearch.buffer_queue_limit": "30",
-		}),
-	)
-
-	var daemon *v1beta2.DaemonSet
-	helmChartParser.Find(common.SearchResourceOption{
-		Name: "release-name-fluentd-elasticsearch",
-		Kind: "DaemonSet",
-	}, &daemon)
-
-	require.Equal(t, "30", daemon.Spec.Template.Spec.Containers[0].Env[5].Value)
-}
-
-var deployEfkResources = []common.SearchResourceOption{
+var deployEfkResources = []SearchResourceOption{
 	{
-		Name: "release-name-kibana",
-		Kind: "ConfigMap",
-	},
-	{
-		Name: "release-name-kibana",
+		Name: "pega-kibana",
 		Kind: "Service",
 	},
 	{
-		Name: "release-name-kibana",
+		Name: "pega-kibana",
 		Kind: "Deployment",
 	},
 	{
-		Name: "elastic-search",
-		Kind: "ConfigMap",
-	},
+		Name: "pega-kibana",
+		Kind: "Ingress",
+	},	
 	{
-		Name: "elastic-search-data",
+		Name: "elasticsearch-master",
 		Kind: "StatefulSet",
 	},
 	{
-		Name: "elastic-search-master",
-		Kind: "StatefulSet",
+		Name: "elasticsearch-master-pdb",
+		Kind: "PodDisruptionBudget",
 	},
 	{
-		Name: "elastic-search-client",
-		Kind: "ServiceAccount",
-	},
-	{
-		Name: "elastic-search-data",
-		Kind: "ServiceAccount",
-	},
-	{
-		Name: "elastic-search-master",
-		Kind: "ServiceAccount",
-	},
-	{
-		Name: "elastic-search-client",
+		Name: "elasticsearch-master",
 		Kind: "Service",
 	},
 	{
-		Name: "elastic-search-discovery",
+		Name: "elasticsearch-master-headless",
 		Kind: "Service",
 	},
 	{
-		Name: "elastic-search-client",
-		Kind: "Deployment",
-	},
-	{
-		Name: "release-name-fluentd-elasticsearch",
+		Name: "pega-fluentd-elasticsearch",
 		Kind: "ConfigMap",
 	},
 	{
-		Name: "release-name-fluentd-elasticsearch",
+		Name: "pega-fluentd-elasticsearch",
 		Kind: "ServiceAccount",
 	},
 	{
-		Name: "release-name-fluentd-elasticsearch",
-		Kind: "ClusterRole",
-	},
-	{
-		Name: "release-name-fluentd-elasticsearch",
-		Kind: "ClusterRoleBinding",
-	},
-	{
-		Name: "release-name-fluentd-elasticsearch",
+		Name: "pega-fluentd-elasticsearch",
 		Kind: "DaemonSet",
 	},
 }

--- a/terratest/src/test/addons/efk_test.go
+++ b/terratest/src/test/addons/efk_test.go
@@ -4,6 +4,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/api/apps/v1beta2"
 	"k8s.io/api/extensions/v1beta1"
+	"test/common"
 	"testing"
 )
 


### PR DESCRIPTION
Upgrading below addons charts version to make them compatible with Kubernetes 1.16 or greater
elasticsearch (7.8.1)
fluentd-elasticsearch (9.6.0)
kibana (7.8.1)
ingress-azure (1.2.0)