### PR TITLE
ISSUE-177 Add helm hook to force helm to wait until the install is complete

### DIFF
--- a/charts/pega/charts/installer/templates/_pega-installer-job.tpl
+++ b/charts/pega/charts/installer/templates/_pega-installer-job.tpl
@@ -5,6 +5,13 @@ apiVersion: batch/v1
 metadata:
   name: {{ .name }}
   namespace: {{ .root.Release.Namespace }}
+{{- if or (eq .root.Values.global.actions.execute "install") (eq .root.Values.global.actions.execute "upgrade") }}
+  annotations:
+    # Forces Helm to wait for the install or upgrade to complete.
+    "helm.sh/hook": post-install
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": before-hook-creation
+{{- end }}
 spec:
   backoffLimit: 0
   template:

--- a/charts/pega/charts/installer/templates/_pega-installer-job.tpl
+++ b/charts/pega/charts/installer/templates/_pega-installer-job.tpl
@@ -5,7 +5,7 @@ apiVersion: batch/v1
 metadata:
   name: {{ .name }}
   namespace: {{ .root.Release.Namespace }}
-{{- if or (eq .root.Values.global.actions.execute "install") (eq .root.Values.global.actions.execute "upgrade") }}
+{{- if and .root.Values.waitForJobCompletion (or (eq .root.Values.global.actions.execute "install") (eq .root.Values.global.actions.execute "upgrade")) }}
   annotations:
     # Forces Helm to wait for the install or upgrade to complete.
     "helm.sh/hook": post-install

--- a/charts/pega/charts/installer/values.yaml
+++ b/charts/pega/charts/installer/values.yaml
@@ -32,6 +32,8 @@ distributionKitVolumeClaimName: ""
 bypassLoadEngineClasses: "false"
 # Bypass loading assembly classes into database
 bypassLoadAssembledClasses: "false"
+# If 'true', Helm will wait for the install or upgrade to finish, and only succeed if the job completes without error.
+waitForJobCompletion: "false"
 threads:
   # Maximum Idle Thread.Default is 5
   maxIdle: 5


### PR DESCRIPTION
Fixes #177 

Previously, running the install or upgrade action would exit helm as soon as all resources were deployed, not when the job was completed. Adding these hooks causes helm to wait until the resources are fully deployed. Note that we can only include install and upgrade (and not any deploy-related action) because otherwise we have a cyclical dependency (post-install hook + waiting for install to complete).