### PR TITLE
make default environment variables as empty in aws-alb-ingress-controller

### DIFF
--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -49,8 +49,8 @@ aws-alb-ingress-controller:
   ## Required if autoDiscoverAwsVpcID != true
   awsVpcID: "YOUR_EKS_CLUSTER_VPC_ID"
   extraEnv: {}
-    # AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
-    # AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
+  # AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
+  # AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
 
 # Configure EFK stack for logging:
 # For a complete EFK stack: elasticsearch, fluentd-elasticsearch, and kibana should all be enabled

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -48,9 +48,9 @@ aws-alb-ingress-controller:
   ## VPC ID of k8s cluster, required if ec2metadata is unavailable from controller pod
   ## Required if autoDiscoverAwsVpcID != true
   awsVpcID: "YOUR_EKS_CLUSTER_VPC_ID"
-  extraEnv:
-    AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
-    AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
+  extraEnv: {}
+    # AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
+    # AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
 
 # Configure EFK stack for logging:
 # For a complete EFK stack: elasticsearch, fluentd-elasticsearch, and kibana should all be enabled


### PR DESCRIPTION
Here, default environment variables are specified for AWS authentication. But Authentication can be done in other ways without specifying these env variables. 
The default behaviour of helm is to merge the Map values of user-given(using --values or --set) and default values.
So, If we leave the **extraEnv** with some values, these values always will be there in the deployment which is unnecessary and cause other problems.