### PR TITLE
Provide an empty template so that parent charts can override to provi…

### DIFF
--- a/charts/pega/templates/_helpers.tpl
+++ b/charts/pega/templates/_helpers.tpl
@@ -214,3 +214,7 @@ true
 {{- end }}
 {{- end }}
 {{- end }}
+
+#Override this template to generate additional pod annotations that are dynamically composed during helm deployment (do not indent annotations)
+{{- define "generatedPodAnnotations" }}
+{{- end }}

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -34,6 +34,7 @@ spec:
 {{- end }}
         config-check: {{ include (print .root.Template.BasePath "/pega-environment-config.yaml") .root | sha256sum }}
         revision: "{{ .root.Release.Revision }}"
+{{- include "generatedPodAnnotations" . | indent 8 }}
 
     spec:
       volumes:


### PR DESCRIPTION
Provide an empty template to the pega-helm-chart that can by overridden in a parent chart for the purpose of generating pod annotations at deployment time.