### PR TITLE
Add support from specifying additional volumes, volume mounts and env…

### DIFF
--- a/charts/pega/charts/installer/templates/_helpers.tpl
+++ b/charts/pega/charts/installer/templates/_helpers.tpl
@@ -92,24 +92,4 @@
 {{- end }}
 {{- end }}
 
-#Override this template to define custom volumes (do not indent)
-{{- define "customInstallerVolumes" }}
-{{- end }}
-
-#Override this template to define custom volume mounts (do not indent)
-{{- define "customInstallerVolumeMounts" }}
-{{- end }}
-
-#Override this template to define environment entries (do not indent)
-{{- define "customInstallerEnvEntries" }}
-{{- end }}
-
-{{- define "customInstallerEnv" }}
-{{- $customEnvEntries := include "customInstallerEnvEntries" . }}
-{{- if ne "" $customEnvEntries }}
-env:
-{{- include "customInstallerEnvEntries" . }} 
-{{- end }}
-{{- end }}
-
 

--- a/charts/pega/charts/installer/templates/_helpers.tpl
+++ b/charts/pega/charts/installer/templates/_helpers.tpl
@@ -91,3 +91,25 @@
     value: {{ $apiserver.httpsServicePort | quote }}
 {{- end }}
 {{- end }}
+
+#Override this template to define custom volumes (do not indent)
+{{- define "customInstallerVolumes" }}
+{{- end }}
+
+#Override this template to define custom volume mounts (do not indent)
+{{- define "customInstallerVolumeMounts" }}
+{{- end }}
+
+#Override this template to define environment entries (do not indent)
+{{- define "customInstallerEnvEntries" }}
+{{- end }}
+
+{{- define "customInstallerEnv" }}
+{{- $customEnvEntries := include "customInstallerEnvEntries" . }}
+{{- if ne "" $customEnvEntries }}
+env:
+{{- include "customInstallerEnvEntries" . }} 
+{{- end }}
+{{- end }}
+
+

--- a/charts/pega/charts/installer/templates/_pega-installer-job.tpl
+++ b/charts/pega/charts/installer/templates/_pega-installer-job.tpl
@@ -34,7 +34,12 @@ spec:
           name: {{ template "pegaInstallConfig"}}
           # Used to specify permissions on files within the volume.
           defaultMode: 420
-{{- include "customInstallerVolumes" . | indent 6 }}          
+{{- if .root.Values.custom }}
+{{- if .root.Values.custom.volumes }}
+      # Additional custom volumes
+{{ toYaml .root.Values.custom.volumes | indent 6 }}
+{{- end }}
+{{- end }}          
       initContainers:
 {{- range $i, $val := .initContainers }}
 {{ include $val $.root | indent 6 }}
@@ -62,18 +67,34 @@ spec:
         - name: {{ template "pegaDistributionKitVolume" }}
           mountPath: "/opt/pega/mount/kit"                           
 {{- end }}
-{{- include "customInstallerVolumeMounts" . | indent 8 }}      
+{{- if .root.Values.custom }}
+{{- if .root.Values.custom.volumeMounts }}
+        # Additional custom mounts
+{{ toYaml .root.Values.custom.volumeMounts | indent 8 }}
+{{- end }}
+{{- end }}
 {{- if or (eq $arg "pre-upgrade") (eq $arg "post-upgrade") (eq $arg "upgrade")  }}
         env:
         -  name: ACTION
            value: {{ .action }}
-{{- include "customInstallerEnvEntries" . | indent 8 }}
+{{- if .root.Values.custom }}
+{{- if .root.Values.custom.env }}
+        # Additional custom env vars
+{{ toYaml .root.Values.custom.env | indent 8 }}
+{{- end }}
+{{- end }}
         envFrom:
         - configMapRef:
             name: {{ template "pegaUpgradeEnvironmentConfig" }}
 {{- end }}
 {{- if (eq $arg "install") }}
-{{- include "customInstallerEnv" . | indent 8 }}
+{{- if .root.Values.custom }}
+{{- if .root.Values.custom.env }}
+        env:
+        # Additional custom env vars
+{{ toYaml .root.Values.custom.env | indent 8 }}
+{{- end }}
+{{- end }}
         envFrom:
         - configMapRef:
             name: {{ template "pegaInstallEnvironmentConfig" }}

--- a/charts/pega/charts/installer/templates/_pega-installer-job.tpl
+++ b/charts/pega/charts/installer/templates/_pega-installer-job.tpl
@@ -33,7 +33,8 @@ spec:
           # This name will be referred in the volume mounts kind.
           name: {{ template "pegaInstallConfig"}}
           # Used to specify permissions on files within the volume.
-          defaultMode: 420          
+          defaultMode: 420
+{{- include "customInstallerVolumes" . | indent 6 }}          
       initContainers:
 {{- range $i, $val := .initContainers }}
 {{ include $val $.root | indent 6 }}
@@ -60,16 +61,19 @@ spec:
 {{- if and .root.Values.distributionKitVolumeClaimName (not .root.Values.distributionKitURL) }}          
         - name: {{ template "pegaDistributionKitVolume" }}
           mountPath: "/opt/pega/mount/kit"                           
-{{- end }}      
+{{- end }}
+{{- include "customInstallerVolumeMounts" . | indent 8 }}      
 {{- if or (eq $arg "pre-upgrade") (eq $arg "post-upgrade") (eq $arg "upgrade")  }}
         env:
         -  name: ACTION
            value: {{ .action }}
+{{- include "customInstallerEnvEntries" . | indent 8 }}
         envFrom:
         - configMapRef:
             name: {{ template "pegaUpgradeEnvironmentConfig" }}
 {{- end }}
 {{- if (eq $arg "install") }}
+{{- include "customInstallerEnv" . | indent 8 }}
         envFrom:
         - configMapRef:
             name: {{ template "pegaInstallEnvironmentConfig" }}


### PR DESCRIPTION
Add support from specifying additional volumes, volume mounts and environment vars to to the installer job in an effort to integrate with external secrets.

This PR (in conjunction with changes to the installer-ready-image) allows you to source the secrets used by the pega installer from a 3rd party secret management tool when subcharting the pega-helm-charts.  In order to take advantage of this:
--Include pega-helm-chart as a subchart.
--Override the "customInstallerVolumes" template in your chart to provide custom volumes sourced from your secret value:
```
{{- define "customInstallerVolumes" }}
- name: my-external-secret-volume1
  secret:
    secretName: my-external-secret1
    defaultMode: 420
{{- end }}
```
--Override the "customInstallerVolumeMounts" template in your chart to mount your volume:
```
{{- define "customInstallerVolumeMounts" }}
- name: my-external-secret-volume1
  mountPath: /opt/pega/ext-secret1
{{- end }}
```
--Override the "customInstallerEnvEntries" template in your chart so that you specify the mountPath of your volume:
```
{{- define "customInstallerEnvEntries" }}
- name: DB_USERNAME_SECRET_PATH
  value: /opt/pega/ext-secret1
{{- end }}
```

This PR allows you to specify both DB_USERNAME_SECRET_PATH or DB_PASSWORD_SECRET_PATH only.