### PR TITLE
Allow for parent chart to override registry secret to allow for using…

### DIFF
--- a/charts/pega/templates/_pega-registry-secret.tpl
+++ b/charts/pega/templates/_pega-registry-secret.tpl
@@ -1,0 +1,10 @@
+{{- define "pegaRegistryCredentialsSecretTemplate" }}
+kind: Secret
+apiVersion: v1
+metadata:
+  name: {{ template "pegaRegistrySecret" }}
+  namespace: {{ .Release.Namespace }}
+data:
+  .dockerconfigjson: {{ template "imagePullSecret" . }}
+type: kubernetes.io/dockerconfigjson
+{{- end }}

--- a/charts/pega/templates/pega-registry-secret.yaml
+++ b/charts/pega/templates/pega-registry-secret.yaml
@@ -1,8 +1,1 @@
-kind: Secret
-apiVersion: v1
-metadata:
-  name: {{ template "pegaRegistrySecret" }}
-  namespace: {{ .Release.Namespace }}
-data:
-  .dockerconfigjson: {{ template "imagePullSecret" . }}
-type: kubernetes.io/dockerconfigjson
+{{- include "pegaRegistryCredentialsSecretTemplate" . }}


### PR DESCRIPTION
Allow for parent chart to override registry secret to allow for using external secret tools.

The change included in this PR will allow for the pega-registry-secret to be overridden by a parent chart to enable the use of 3rd party external secret tools.  This is related to the changes introduced by https://github.com/pegasystems/pega-helm-charts/pull/189 .

These changes wrap the pega-registry-secret in a named template.  To override the secret, the parent chart needs to override the named template.  