### PR TITLE
Pass the correct context to the generatedPodAnnotations template so t…

### DIFF
--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -34,7 +34,7 @@ spec:
 {{- end }}
         config-check: {{ include (print .root.Template.BasePath "/pega-environment-config.yaml") .root | sha256sum }}
         revision: "{{ .root.Release.Revision }}"
-{{- include "generatedPodAnnotations" . | indent 8 }}
+{{- include "generatedPodAnnotations" .root | indent 8 }}
 
     spec:
       volumes:


### PR DESCRIPTION
Pass the correct context to the generatedPodAnnotations template so that it can access .Values.global.*

The issue being resolved is that the wrong context was being passed into the generatedPodAnnotations template in _pega-deployment.tpl -- this resulted in only being able to reference properties contained in the corresponding .Values.global.tier[] context.  This is problematic as it would that the configuration would have to be replicated in each tier resulting in duplicate configuration likely to cause maintenance headaches in the future.

As of this change, referencing ```.Values.global.*``` can be performed like so from the generatePodAnnotations template:
```
{{- define "generatedPodAnnotations" }}
ad.datadoghq.com/pega-web-tomcat.instances: '{{ toJson (.Values.global.dd_metrics).instances }}'
{{- end }}
```
