### PR TITLE
ISSUE-207 Add urlPath and probe port and Fix logLevel arg in constell…

### DIFF
--- a/charts/pega/charts/constellation/templates/clln-deployment.yaml
+++ b/charts/pega/charts/constellation/templates/clln-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     app: constellation
 spec:
-  replicas: 2
+  replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
       app: constellation
@@ -24,14 +24,27 @@ spec:
         image: {{ .Values.image }}
         args:
         - port=3000
-        - {{ .Values.logLevel }}
+        # constellation URL path, if you change it, you need to change ingress template files too 
+        - urlPath=/c11n
+        - logLevel={{ .Values.logLevel }}
         livenessProbe:
+          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+          successThreshold: {{ .Values.livenessProbe.successThreshold }}
+          failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
           httpGet:
             path: /c11n/api/v1/ping
+            port: 3000
         readinessProbe:
-          initialDelaySeconds: 1
+          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+          successThreshold: {{ .Values.readinessProbe.successThreshold }}
+          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
           httpGet:
             path: /c11n/api/v1/ping
+            port: 3000
         ports:
         - containerPort: 3000
 {{ end }}

--- a/charts/pega/charts/constellation/values.yaml
+++ b/charts/pega/charts/constellation/values.yaml
@@ -5,3 +5,16 @@ image: IMAGE_REPO_URL_HERE
 # log level : error, warn, info, debug.  use error for production
 logLevel: info
 enabled: false
+replicas: 2
+livenessProbe:
+  initialDelaySeconds: 5
+  timeoutSeconds: 5
+  periodSeconds: 30
+  successThreshold: 1
+  failureThreshold: 3
+readinessProbe:
+  initialDelaySeconds: 5
+  timeoutSeconds: 5
+  periodSeconds: 30
+  successThreshold: 1
+  failureThreshold: 3


### PR DESCRIPTION
ISSUE-207 Add urlPath and probe port and Fix logLevel arg in constelation deployment (and other small enhancements)

1. Set /c11n as urlPath to fix liveness/readiness probe
2. Add missing probe port which is mandatory
3. Fix incorrect logLevel argument passed to container
5. Make replicas configurable
6. Make livenessProbe/readinessProbe parameters configurable