### PR TITLE
option to include serviceAccountName in deployments

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -426,6 +426,20 @@ tier:
         - name: MY_ENV_NAME
           value: MY_ENV_VALUE
 ```
+
+### Service Account
+
+If the pod needs to be run with a specific [service account](https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/), you can specify a custom `serviceAccountName` for your deployment tier.
+
+Example:
+
+```yaml
+tier:
+  - name: my-tier
+    custom:
+      serviceAccountName: MY_SERVICE_ACCOUNT_NAME
+```
+
 ### Custom Annotations for Pods
 
 You may optionally provide custom annotations for Pods as metadata to be consumed by other tools and libraries. Pod annotations may be specified by using the `podAnnotations` element for a given `tier`.

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -44,6 +44,11 @@ spec:
 {{- include "generatedPodAnnotations" .root | indent 8 }}
 
     spec:
+{{- if .custom }}
+{{- if .custom.serviceAccountName }}
+      serviceAccountName: {{ .custom.serviceAccountName }}
+{{- end }}
+{{- end }}
       volumes:
       # Volume used to mount config files.
       - name: {{ template "pegaVolumeConfig" }}


### PR DESCRIPTION
In FNX all deployments need `serviceAccountName: pega-infinity-sa` to communicate with backing-services. Currently no way to set that.