### PR TITLE
Allow Openshift to use arbitrary user at runtime.

### DIFF
--- a/charts/pega/charts/pegasearch/templates/pega-search-deployment.yaml
+++ b/charts/pega/charts/pegasearch/templates/pega-search-deployment.yaml
@@ -56,8 +56,10 @@ spec:
 {{- if ( .Values.imagePullPolicy ) }}
         imagePullPolicy: {{ .Values.imagePullPolicy }}
 {{- end }}
+        {{ if ne .Values.global.provider "openshift" }}
         securityContext:
           runAsUser: {{ .Values.podSecurityContext.runAsUser | default 1000 }}
+        {{- end }}
         env:
         - name: HOST_LIST
           value: {{ template "searchName" . }}-transport


### PR DESCRIPTION
Disabling the use of runAsUser in search container for Openshift and allowing the use of arbitrary user at runtime.