### PR TITLE
Update cassandra and ALB chart repo to use latest migrated repository

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,95 @@
+#!/usr/bin/env groovy
+def bintrayautomation = "bintrayautomation"
+def labels = ""
+def bintrayPackageVersion = "1.0.0" 
+def curlSuccessStatus = '{"message":"success"}'
+
+node("pc-2xlarge") {
+
+      stage("Init"){
+          if (env.CHANGE_ID) {
+            pullRequest.labels.each{
+            echo "label: $it"
+            validateProviderLabel(it)
+            labels += "$it,"
+            }
+            labels = labels.substring(0,labels.length()-1)
+            echo "PR labels -> $labels"
+            // Comment on PR about the text execution
+            pullRequest.comment("Starting ${env.BRANCH_NAME} validation on -> $labels")
+            sh "curl -fsSL -o helm-v3.2.4-linux-amd64.tar.gz https://get.helm.sh/helm-v3.2.4-linux-amd64.tar.gz"
+            sh "tar -zxvf helm-v3.2.4-linux-amd64.tar.gz"
+            sh "mv linux-amd64/helm /usr/local/bin/helm"
+          } else {
+            currentBuild.result = 'ABORTED'
+            throw new Exception("Aborting as this is not a PR job")
+         }
+      }
+      stage ("Checkout and Package Charts") {
+
+            // Checkout PR Code
+            def scmVars = checkout scm
+            branchName = "${scmVars.GIT_BRANCH}"
+            packageName = currentBuild.displayName
+            prNumber = "${env.BRANCH_NAME}".split("-")[1]
+            
+            // Perform Chart packaging
+            sh "helm dependency update ./charts/pega/"
+            sh "helm dependency update ./charts/addons/"
+            sh "curl -o index.yaml https://dl.bintray.com/pegasystems/helm-test-automation/index.yaml"
+            sh "helm package --version ${prNumber}.${env.BUILD_NUMBER} ./charts/pega/"
+            sh "helm package --version ${prNumber}.${env.BUILD_NUMBER} ./charts/addons/"
+            sh "helm repo index --merge index.yaml --url https://dl.bintray.com/pegasystems/helm-test-automation/ ."
+            sh "cat index.yaml"
+            
+            // Publish helm charts to test-automation repository
+            withCredentials([usernamePassword(credentialsId: "bintrayautomation",
+              passwordVariable: 'BINTRAY_APIKEY', usernameVariable: 'BINTRAY_USERNAME')]) {
+                chartVersion = "${prNumber}.${env.BUILD_NUMBER}"
+                pega_chartName = "pega-${chartVersion}.tgz"
+                addons_chartName = "addons-${chartVersion}.tgz"
+                DELETE_STATUS_CODE = sh(script: "curl -X DELETE -u${BINTRAY_USERNAME}:${BINTRAY_APIKEY} https://api.bintray.com/content/pegasystems/helm-test-automation/index.yaml --write-out '%{http_code}'", returnStdout: true).trim()
+                PEGA_STATUS_CODE = sh(script: "curl -T ${pega_chartName} -u${BINTRAY_USERNAME}:${BINTRAY_APIKEY} https://api.bintray.com/content/pegasystems/helm-test-automation/helm-test-automation/${bintrayPackageVersion}/ --write-out '%{http_code}'", returnStdout: true).trim()
+                ADDONS_STATUS_CODE = sh(script: "curl -T ${addons_chartName} -u${BINTRAY_USERNAME}:${BINTRAY_APIKEY} https://api.bintray.com/content/pegasystems/helm-test-automation/helm-test-automation/${bintrayPackageVersion}/ --write-out '%{http_code}' ", returnStdout: true).trim()
+                UPDATE_STATUS_CODE = sh(script: "curl -T index.yaml -u${BINTRAY_USERNAME}:${BINTRAY_APIKEY} https://api.bintray.com/content/pegasystems/helm-test-automation/helm-test-automation/${bintrayPackageVersion}/ --write-out '%{http_code}'", returnStdout: true).trim()
+                PUBLISH_STATUS_CODE = sh(script: "curl -X POST -u${BINTRAY_USERNAME}:${BINTRAY_APIKEY} https://api.bintray.com/content/pegasystems/helm-test-automation/helm-test-automation/${bintrayPackageVersion}/publish --write-out '%{http_code}'", returnStdout: true).trim()
+                echo "DELETE_STATUS_CODE-- ${DELETE_STATUS_CODE}"
+                echo "PEGA_STATUS_CODE-- ${PEGA_STATUS_CODE}"
+                echo "ADDONS_STATUS_CODE-- ${ADDONS_STATUS_CODE}"
+                echo "UPDATE_STATUS_CODE-- ${UPDATE_STATUS_CODE}"
+                echo "PUBLISH_STATUS_CODE-- ${PUBLISH_STATUS_CODE}"
+
+                if ( "${DELETE_STATUS_CODE}" != "${curlSuccessStatus}"+"200" || "${PEGA_STATUS_CODE}" != "${curlSuccessStatus}"+"201" || "${ADDONS_STATUS_CODE}" != "${curlSuccessStatus}"+"201"
+                      || "${UPDATE_STATUS_CODE}" != "${curlSuccessStatus}"+"201" || "${PUBLISH_STATUS_CODE}" != '{"files":3}'+"200" ) {
+                    currentBuild.result = 'FAILURE'
+                    pullRequest.comment("Unable to publish helm charts to bintray repository. Please retry")
+                    error "This pipeline stops here! Unable to perform helm charts publish to bintray repository."
+                }
+            } 
+      }
+
+      stage("Setup Cluster and Execute Tests") {
+          
+          jobMap = [:]
+          jobMap["job"] = "../kubernetes-test-orchestrator/US-366319"
+          jobMap["parameters"] = [
+                                  string(name: 'PROVIDERS', value: labels),
+                                  string(name: 'WEB_READY_IMAGE_NAME', value: ""),
+                                  string(name: 'HELM_CHART_VERSION', value: chartVersion),
+                              ]
+          jobMap["propagate"] = true
+          jobMap["quietPeriod"] = 0 
+          resultWrapper = build jobMap
+          currentBuild.result = resultWrapper.result
+          echo "Into Trigger Orchestrator"
+      } 
+  }
+
+def validateProviderLabel(String provider){
+    def validProviders = ["integ-all","integ-eks","integ-gke","integ-aks"]
+    if(!validProviders.contains(provider)){
+        currentBuild.result = 'FAILURE'
+        pullRequest.comment("Invalid provider label - ${provider}. valid labels are ${validProviders}")
+        throw new Exception("Invalid provider label - ${provider}. valid labels are ${validProviders}")
+    }
+}

--- a/charts/addons/README.md
+++ b/charts/addons/README.md
@@ -44,30 +44,26 @@ traefik:
 
 ### Amazon ALB
 
-When deploying on EKS, you can use the native Amazon Load Balancer (ALB). In the Addons Helm chart: disable Traefik (set `traefik.enabled` to `false`) and enable ALB (set `aws-alb-ingress-controller.enabled` to `true`)
+When deploying on AWS EKS, set the parameters, install `aws-load-balancer-controller.enabled` and `metrics-server` to true, `traefik` to false and then fill in the remaining parameters with your EKS environment details.
 
 Configuration   | Usage
 ---             | ---
 `clusterName`   | The name of your EKS cluster.  Resources created by the ALB Ingress controller will be prefixed with this string.
-`autoDiscoverAwsRegion` | Auto discover awsRegion from ec2metadata, set this to true and omit awsRegion when ec2metadata is available.
-`awsRegion`     | AWS region of the EKS cluster. Required if if ec2metadata is unavailable from the controller Pod or if `autoDiscoverAwsRegion` is not `true`.
-`autoDiscoverAwsVpcID` | Auto discover awsVpcID from ec2metadata, set this to true and omit awsVpcID when ec2metadata is available.
-`awsVpcID`      | VPC ID of EKS cluster, required if ec2metadata is unavailable from controller pod. Required if if ec2metadata is unavailable from the controller Pod or if `autoDiscoverAwsVpcID` is not `true`.
-`extraEnv.AWS_ACCESS_KEY_ID` and `extraEnv.AWS_SECRET_ACCESS_KEY` | The access key and secret access key with access to configure AWS resources.
+`region`     | AWS region of the EKS cluster. Required if if ec2metadata is unavailable from the controller Pod.
+`vpcId`      | VPC ID of EKS cluster, required if ec2metadata is unavailable from controller pod.
+`serviceAccount.annotations`  | Annotate the service account with `eks.amazonaws.com/role-arn` IAM Role that provides access to AWS resources.
 
 Example:
 
 ```yaml
-aws-alb-ingress-controller:
-  enabled: false
+aws-load-balancer-controller:
+  enabled: true
   clusterName: "YOUR_EKS_CLUSTER_NAME"
-  autoDiscoverAwsRegion: true
-  awsRegion: "YOUR_EKS_CLUSTER_REGION"
-  autoDiscoverAwsVpcID: true
-  awsVpcID: "YOUR_EKS_CLUSTER_VPC_ID"
-  extraEnv:
-    AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
-    AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
+  region: "YOUR_EKS_CLUSTER_REGION"
+  vpcId: "YOUR_EKS_CLUSTER_VPC_ID"
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: "YOUR_IAM_ROLE_ARN"
 ```
 
 ### Azure AGIC

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -3,10 +3,10 @@ dependencies:
   version: "1.77.1"
   repository: https://charts.helm.sh/stable
   condition: traefik.enabled
-- name: aws-alb-ingress-controller
-  version: "1.0.2"
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
-  condition: aws-alb-ingress-controller.enabled
+- name: aws-load-balancer-controller
+  version: "1.1.0"
+  repository: https://aws.github.io/eks-charts
+  condition: aws-load-balancer-controller.enabled
 - name: elasticsearch
   version: "7.8.1"
   repository: https://helm.elastic.co/

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -38,10 +38,7 @@ aws-load-balancer-controller:
   enabled: false
   ## Resources created by the ALB Ingress controller will be prefixed with this string
   clusterName: "YOUR_EKS_CLUSTER_NAME"
-  ## Auto Discover awsRegion from ec2metadata, set this to true and omit awsRegion when ec2metadata is available.
-  autoDiscoverAwsRegion: false
   ## AWS region of k8s cluster, required if ec2metadata is unavailable from controller pod
-  ## Required if autoDiscoverAwsRegion != true
   region: "YOUR_EKS_CLUSTER_REGION"
   ## VPC ID of k8s cluster, required if ec2metadata is unavailable from controller pod
   vpcId: "YOUR_EKS_CLUSTER_VPC_ID"

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -46,7 +46,7 @@ aws-load-balancer-controller:
   ## VPC ID of k8s cluster, required if ec2metadata is unavailable from controller pod
   vpcId: "YOUR_EKS_CLUSTER_VPC_ID"
   ## To create IAM Role, see https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html#create-service-account-iam-role
-  ## Create policy with https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json and 
+  ## Create policy with https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json and
   ## attach it to the role. See, https://github.com/aws/eks-charts/tree/master/stable/aws-load-balancer-controller for more details
   serviceAccount:
     annotations:

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -45,7 +45,7 @@ aws-load-balancer-controller:
   region: "YOUR_EKS_CLUSTER_REGION"
   ## VPC ID of k8s cluster, required if ec2metadata is unavailable from controller pod
   ## Required if autoDiscoverAwsVpcID != true
-  vpcId: ""
+  vpcId: "YOUR_EKS_CLUSTER_VPC_ID"
   env: {}
   # AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
   # AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -44,11 +44,13 @@ aws-load-balancer-controller:
   ## Required if autoDiscoverAwsRegion != true
   region: "YOUR_EKS_CLUSTER_REGION"
   ## VPC ID of k8s cluster, required if ec2metadata is unavailable from controller pod
-  ## Required if autoDiscoverAwsVpcID != true
   vpcId: "YOUR_EKS_CLUSTER_VPC_ID"
-  env: {}
-  # AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
-  # AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
+  ## To create IAM Role, see https://docs.aws.amazon.com/eks/latest/userguide/create-service-account-iam-policy-and-role.html#create-service-account-iam-role
+  ## Create policy with https://raw.githubusercontent.com/kubernetes-sigs/aws-load-balancer-controller/main/docs/install/iam_policy.json and 
+  ## attach it to the role. See, https://github.com/aws/eks-charts/tree/master/stable/aws-load-balancer-controller for more details
+  serviceAccount:
+    annotations:
+      eks.amazonaws.com/role-arn: "YOUR_IAM_ROLE_ARN"
 
 # Configure EFK stack for logging:
 # For a complete EFK stack: elasticsearch, fluentd-elasticsearch, and kibana should all be enabled

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -33,8 +33,8 @@ traefik:
       # Enter the memory limit for Traefik
       memory: 500Mi
 
-# When deploying on AWS EKS, set this to true to install aws-alb-ingress-controller.
-aws-alb-ingress-controller:
+# When deploying on AWS EKS, set this to true to install aws-load-balancer-controller.
+aws-load-balancer-controller:
   enabled: false
   ## Resources created by the ALB Ingress controller will be prefixed with this string
   clusterName: "YOUR_EKS_CLUSTER_NAME"
@@ -42,13 +42,11 @@ aws-alb-ingress-controller:
   autoDiscoverAwsRegion: false
   ## AWS region of k8s cluster, required if ec2metadata is unavailable from controller pod
   ## Required if autoDiscoverAwsRegion != true
-  awsRegion: "YOUR_EKS_CLUSTER_REGION"
-  ## Auto Discover awsVpcID from ec2metadata, set this to true and omit awsVpcID: " when ec2metadata is available.
-  autoDiscoverAwsVpcID: false
+  region: "YOUR_EKS_CLUSTER_REGION"
   ## VPC ID of k8s cluster, required if ec2metadata is unavailable from controller pod
   ## Required if autoDiscoverAwsVpcID != true
-  awsVpcID: "YOUR_EKS_CLUSTER_VPC_ID"
-  extraEnv: {}
+  vpcId: ""
+  env: {}
   # AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
   # AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
 

--- a/charts/pega/requirements.yaml
+++ b/charts/pega/requirements.yaml
@@ -1,5 +1,5 @@
 dependencies:
 - name: cassandra
   version: "0.13.3"
-  repository: https://kubernetes-charts-incubator.storage.googleapis.com/
+  repository: https://charts.helm.sh/incubator
   condition: cassandra.enabled

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -30,7 +30,7 @@ metadata:
 {{- end }}
 spec:
   type:
-  {{- if (eq .root.Values.global.provider "gke") -}}
+  {{- if or (eq .root.Values.global.provider "gke") (eq .root.Values.global.provider "eks") -}}
   {{ indent 1 "NodePort" }}
   {{- else -}}
   {{ indent 1 (.node.service.serviceType | default "LoadBalancer") }}

--- a/charts/pega/templates/pega-tier-ingress.yaml
+++ b/charts/pega/templates/pega-tier-ingress.yaml
@@ -1,6 +1,5 @@
 {{- range $index, $dep := .Values.global.tier }}
 {{ if and (eq (include "performDeployment" $ ) "true") ($dep.service) }}
-{{ $alb := index $.Values "aws-alb-ingress-controller" }}
 {{- if eq $.Values.global.provider "openshift" -}}
 {{ template "pega.openshift.ingress" dict "root" $ "node" $dep "name" (printf "pega-%s" $dep.name) }}
 {{- else if and (eq $.Values.global.provider "eks") -}}

--- a/terratest/src/test/addons/alb-ingress_test.go
+++ b/terratest/src/test/addons/alb-ingress_test.go
@@ -69,7 +69,7 @@ func Test_checkAutoDiscoverAwsRegion(t *testing.T) {
 		Kind: "Deployment",
 	}, &deployment)
 
-	require.NotContains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--aws-region=YOUR_EKS_CLUSTER_REGION")
+	require.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--aws-region=YOUR_EKS_CLUSTER_REGION")
 }
 
 func Test_checkSetAwsVpcID(t *testing.T) {

--- a/terratest/src/test/addons/alb-ingress_test.go
+++ b/terratest/src/test/addons/alb-ingress_test.go
@@ -76,7 +76,6 @@ func Test_checkSetAwsVpcID(t *testing.T) {
 	helmChart := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
 			"aws-load-balancer-controller.enabled":              "true",
-			"aws-load-balancer-controller.autoDiscoverAwsVpcID": "false",
 			"aws-load-balancer-controller.vpcId":             "YOUR_EKS_CLUSTER_VPC_ID",
 		}),
 	)
@@ -88,24 +87,6 @@ func Test_checkSetAwsVpcID(t *testing.T) {
 	}, &deployment)
 
 	require.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--aws-vpc-id=YOUR_EKS_CLUSTER_VPC_ID")
-}
-
-func Test_checkAutoDiscoverAwsVpcID(t *testing.T) {
-	helmChart := NewHelmConfigParser(
-		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-load-balancer-controller.enabled":              "true",
-			"aws-load-balancer-controller.autoDiscoverAwsVpcID": "true",
-			"aws-load-balancer-controller.vpcId":             "YOUR_EKS_CLUSTER_VPC_ID",
-		}),
-	)
-
-	var deployment *v1.Deployment
-	helmChart.Find(SearchResourceOption{
-		Name: "pega-aws-load-balancer-controller",
-		Kind: "Deployment",
-	}, &deployment)
-
-	require.NotContains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--aws-vpc-id=YOUR_EKS_CLUSTER_VPC_ID")
 }
 
 func Test_checkSetClusterName(t *testing.T) {
@@ -131,11 +112,11 @@ var albIngressResources = []SearchResourceOption{
 		Kind: "ServiceAccount",
 	},
 	{
-		Name: "pega-aws-load-balancer-controller",
+		Name: "pega-aws-load-balancer-controller-role",
 		Kind: "ClusterRole",
 	},
 	{
-		Name: "pega-aws-load-balancer-controller",
+		Name: "pega-aws-load-balancer-controller-rolebinding",
 		Kind: "ClusterRoleBinding",
 	},
 	{

--- a/terratest/src/test/addons/alb-ingress_test.go
+++ b/terratest/src/test/addons/alb-ingress_test.go
@@ -9,7 +9,7 @@ import (
 func TestShouldNotContainAlbIngressIfDisabled(t *testing.T) {
 	helmChartParser := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-alb-ingress-controller.enabled": "false",
+			"aws-load-balancer-controller.enabled": "false",
 		}),
 	)
 
@@ -24,7 +24,7 @@ func TestShouldNotContainAlbIngressIfDisabled(t *testing.T) {
 func TestAlbIngressShouldContainAllResources(t *testing.T) {
 	helmChartParser := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-alb-ingress-controller.enabled": "true",
+			"aws-load-balancer-controller.enabled": "true",
 		}),
 	)
 
@@ -39,15 +39,15 @@ func TestAlbIngressShouldContainAllResources(t *testing.T) {
 func Test_checkSetAwsRegion(t *testing.T) {
 	helmChart := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-alb-ingress-controller.enabled":               "true",
-			"aws-alb-ingress-controller.autoDiscoverAwsRegion": "false",
-			"aws-alb-ingress-controller.awsRegion":             "YOUR_EKS_CLUSTER_REGION",
+			"aws-load-balancer-controller.enabled":               "true",
+			"aws-load-balancer-controller.autoDiscoverAwsRegion": "false",
+			"aws-load-balancer-controller.region":             "YOUR_EKS_CLUSTER_REGION",
 		}),
 	)
 
 	var deployment *v1.Deployment
 	helmChart.Find(SearchResourceOption{
-		Name: "pega-aws-alb-ingress-controller",
+		Name: "pega-aws-load-balancer-controller",
 		Kind: "Deployment",
 	}, &deployment)
 
@@ -57,15 +57,15 @@ func Test_checkSetAwsRegion(t *testing.T) {
 func Test_checkAutoDiscoverAwsRegion(t *testing.T) {
 	helmChart := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-alb-ingress-controller.enabled":               "true",
-			"aws-alb-ingress-controller.autoDiscoverAwsRegion": "true",
-			"aws-alb-ingress-controller.awsRegion":             "YOUR_EKS_CLUSTER_REGION",
+			"aws-load-balancer-controller.enabled":               "true",
+			"aws-load-balancer-controller.autoDiscoverAwsRegion": "true",
+			"aws-load-balancer-controller.region":             "YOUR_EKS_CLUSTER_REGION",
 		}),
 	)
 
 	var deployment *v1.Deployment
 	helmChart.Find(SearchResourceOption{
-		Name: "pega-aws-alb-ingress-controller",
+		Name: "pega-aws-load-balancer-controller",
 		Kind: "Deployment",
 	}, &deployment)
 
@@ -75,15 +75,15 @@ func Test_checkAutoDiscoverAwsRegion(t *testing.T) {
 func Test_checkSetAwsVpcID(t *testing.T) {
 	helmChart := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-alb-ingress-controller.enabled":              "true",
-			"aws-alb-ingress-controller.autoDiscoverAwsVpcID": "false",
-			"aws-alb-ingress-controller.awsVpcID":             "YOUR_EKS_CLUSTER_VPC_ID",
+			"aws-load-balancer-controller.enabled":              "true",
+			"aws-load-balancer-controller.autoDiscoverAwsVpcID": "false",
+			"aws-load-balancer-controller.vpcId":             "YOUR_EKS_CLUSTER_VPC_ID",
 		}),
 	)
 
 	var deployment *v1.Deployment
 	helmChart.Find(SearchResourceOption{
-		Name: "pega-aws-alb-ingress-controller",
+		Name: "pega-aws-load-balancer-controller",
 		Kind: "Deployment",
 	}, &deployment)
 
@@ -93,15 +93,15 @@ func Test_checkSetAwsVpcID(t *testing.T) {
 func Test_checkAutoDiscoverAwsVpcID(t *testing.T) {
 	helmChart := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-alb-ingress-controller.enabled":              "true",
-			"aws-alb-ingress-controller.autoDiscoverAwsVpcID": "true",
-			"aws-alb-ingress-controller.awsVpcID":             "YOUR_EKS_CLUSTER_VPC_ID",
+			"aws-load-balancer-controller.enabled":              "true",
+			"aws-load-balancer-controller.autoDiscoverAwsVpcID": "true",
+			"aws-load-balancer-controller.vpcId":             "YOUR_EKS_CLUSTER_VPC_ID",
 		}),
 	)
 
 	var deployment *v1.Deployment
 	helmChart.Find(SearchResourceOption{
-		Name: "pega-aws-alb-ingress-controller",
+		Name: "pega-aws-load-balancer-controller",
 		Kind: "Deployment",
 	}, &deployment)
 
@@ -111,14 +111,14 @@ func Test_checkAutoDiscoverAwsVpcID(t *testing.T) {
 func Test_checkSetClusterName(t *testing.T) {
 	helmChart := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-alb-ingress-controller.enabled":     "true",
-			"aws-alb-ingress-controller.clusterName": "YOUR_EKS_CLUSTER_NAME",
+			"aws-load-balancer-controller.enabled":     "true",
+			"aws-load-balancer-controller.clusterName": "YOUR_EKS_CLUSTER_NAME",
 		}),
 	)
 
 	var deployment *v1.Deployment
 	helmChart.Find(SearchResourceOption{
-		Name: "pega-aws-alb-ingress-controller",
+		Name: "pega-aws-load-balancer-controller",
 		Kind: "Deployment",
 	}, &deployment)
 
@@ -128,15 +128,15 @@ func Test_checkSetClusterName(t *testing.T) {
 func Test_checkSetAccessKey(t *testing.T) {
 	helmChart := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-alb-ingress-controller.enabled":                        "true",
-			"aws-alb-ingress-controller.extraEnv.AWS_ACCESS_KEY_ID":     "YOUR_AWS_ACCESS_KEY_ID",
-			"aws-alb-ingress-controller.extraEnv.AWS_SECRET_ACCESS_KEY": "YOUR_AWS_SECRET_ACCESS_KEY",
+			"aws-load-balancer-controller.enabled":                        "true",
+			"aws-load-balancer-controller.env.AWS_ACCESS_KEY_ID":     "YOUR_AWS_ACCESS_KEY_ID",
+			"aws-load-balancer-controller.env.AWS_SECRET_ACCESS_KEY": "YOUR_AWS_SECRET_ACCESS_KEY",
 		}),
 	)
 
 	var deployment *v1.Deployment
 	helmChart.Find(SearchResourceOption{
-		Name: "pega-aws-alb-ingress-controller",
+		Name: "pega-aws-load-balancer-controller",
 		Kind: "Deployment",
 	}, &deployment)
 
@@ -148,19 +148,19 @@ func Test_checkSetAccessKey(t *testing.T) {
 
 var albIngressResources = []SearchResourceOption{
 	{
-		Name: "pega-aws-alb-ingress-controller",
+		Name: "pega-aws-load-balancer-controller",
 		Kind: "ServiceAccount",
 	},
 	{
-		Name: "pega-aws-alb-ingress-controller",
+		Name: "pega-aws-load-balancer-controller",
 		Kind: "ClusterRole",
 	},
 	{
-		Name: "pega-aws-alb-ingress-controller",
+		Name: "pega-aws-load-balancer-controller",
 		Kind: "ClusterRoleBinding",
 	},
 	{
-		Name: "pega-aws-alb-ingress-controller",
+		Name: "pega-aws-load-balancer-controller",
 		Kind: "Deployment",
 	},
 }

--- a/terratest/src/test/addons/alb-ingress_test.go
+++ b/terratest/src/test/addons/alb-ingress_test.go
@@ -125,27 +125,6 @@ func Test_checkSetClusterName(t *testing.T) {
 	require.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--cluster-name=YOUR_EKS_CLUSTER_NAME")
 }
 
-func Test_checkSetAccessKey(t *testing.T) {
-	helmChart := NewHelmConfigParser(
-		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-load-balancer-controller.enabled":                        "true",
-			"aws-load-balancer-controller.env.AWS_ACCESS_KEY_ID":     "YOUR_AWS_ACCESS_KEY_ID",
-			"aws-load-balancer-controller.env.AWS_SECRET_ACCESS_KEY": "YOUR_AWS_SECRET_ACCESS_KEY",
-		}),
-	)
-
-	var deployment *v1.Deployment
-	helmChart.Find(SearchResourceOption{
-		Name: "pega-aws-load-balancer-controller",
-		Kind: "Deployment",
-	}, &deployment)
-
-	require.Equal(t, "AWS_ACCESS_KEY_ID", deployment.Spec.Template.Spec.Containers[0].Env[0].Name)
-	require.Equal(t, "YOUR_AWS_ACCESS_KEY_ID", deployment.Spec.Template.Spec.Containers[0].Env[0].Value)
-	require.Equal(t, "AWS_SECRET_ACCESS_KEY", deployment.Spec.Template.Spec.Containers[0].Env[1].Name)
-	require.Equal(t, "YOUR_AWS_SECRET_ACCESS_KEY", deployment.Spec.Template.Spec.Containers[0].Env[1].Value)
-}
-
 var albIngressResources = []SearchResourceOption{
 	{
 		Name: "pega-aws-load-balancer-controller",

--- a/terratest/src/test/addons/alb-ingress_test.go
+++ b/terratest/src/test/addons/alb-ingress_test.go
@@ -3,6 +3,7 @@ package addons
 import (
 	"github.com/stretchr/testify/require"
 	v1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"testing"
 )
 

--- a/terratest/src/test/addons/alb-ingress_test.go
+++ b/terratest/src/test/addons/alb-ingress_test.go
@@ -54,24 +54,6 @@ func Test_checkSetAwsRegion(t *testing.T) {
 	require.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--aws-region=YOUR_EKS_CLUSTER_REGION")
 }
 
-func Test_checkAutoDiscoverAwsRegion(t *testing.T) {
-	helmChart := NewHelmConfigParser(
-		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"aws-load-balancer-controller.enabled":               "true",
-			"aws-load-balancer-controller.autoDiscoverAwsRegion": "true",
-			"aws-load-balancer-controller.region":             "YOUR_EKS_CLUSTER_REGION",
-		}),
-	)
-
-	var deployment *v1.Deployment
-	helmChart.Find(SearchResourceOption{
-		Name: "pega-aws-load-balancer-controller",
-		Kind: "Deployment",
-	}, &deployment)
-
-	require.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--aws-region=YOUR_EKS_CLUSTER_REGION")
-}
-
 func Test_checkSetAwsVpcID(t *testing.T) {
 	helmChart := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
@@ -87,6 +69,21 @@ func Test_checkSetAwsVpcID(t *testing.T) {
 	}, &deployment)
 
 	require.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--aws-vpc-id=YOUR_EKS_CLUSTER_VPC_ID")
+}
+
+func Test_checkSetServiceAnnotation(t *testing.T) {
+	helmChart := NewHelmConfigParser(
+		NewHelmTest(t, helmChartRelativePath, map[string]string{
+			"aws-load-balancer-controller.enabled":              "true",
+		}),
+	)
+	var serviceAccount *corev1.ServiceAccount
+	helmChart.Find(SearchResourceOption{
+		Name: "pega-aws-load-balancer-controller",
+		Kind: "ServiceAccount",
+	}, &serviceAccount)
+
+	require.Contains(t, serviceAccount.ObjectMeta.Annotations["eks.amazonaws.com/role-arn"], "YOUR_IAM_ROLE_ARN")
 }
 
 func Test_checkSetClusterName(t *testing.T) {


### PR DESCRIPTION
Travis builds are failing with https://travis-ci.org/github/pegasystems/pega-helm-charts/builds/751186081 chart not found in corresponding repo issues.

Downloading traefik from repo https://charts.helm.sh/stable
Save error occurred: could not find : chart aws-alb-ingress-controller not found in https://kubernetes-charts-incubator.storage.googleapis.com/

Deleting newly downloaded charts, restoring pre-update state

Error: could not find : chart aws-alb-ingress-controller not found in https://kubernetes-charts-incubator.storage.googleapis.com/

Makefile:2: recipe for target 'dependencies' failed

make: *** [dependencies] Error 1

The command "make dependencies" exited with 2.

To Reproduce:
Perform helm dep update and check if dependencies are downloaded properly using "helm dep list" under addons

Expected behavior
All chart dependencies should be downloaded properly without any issues.
The issue is because stable, incubator chart repo used in our charts are deprecated. It should be moved to another repo as per https://helm.sh/blog/new-location-stable-incubator-charts/

References - https://kubernetes-sigs.github.io/aws-load-balancer-controller/guide/upgrade/migrate_v1_v2/

Updated ALB chart and Cassandra chart repositories.