### PR TITLE
Added the recommended default JVM arguments as CATALINA_OPTS

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -354,6 +354,20 @@ Parameter       | Description    | Default value
 `initialHeap`   | This specifies the initial heap size of the JVM.  | `4096m`
 `maxHeap`       | This specifies the maximum heap size of the JVM.  | `7168m`
 
+### JVM Arguments
+You can optionally pass in JVM arguments to Tomcat.  Depending on the parameter/attribute used, the arguments will be placed into `JAVA_OPTS` or `CATALINA_OPTS` environmental variables.
+Some of the Best-practice arguments for JVM tuning are included by default in `CATALINA_OPTS`.
+Pass the required JVM parameters as `catalinaOpts` attributes in respective `values.yaml` file.  
+
+Example:
+```yaml
+tier:
+  - name: my-tier
+    javaOpts: ""
+    catalinaOpts: "-XX:SomeJVMArg=XXX"
+```
+Note that some JVM arguments are non-overrideable i.e. baked in the Docker image. <br>
+Check [RecommendedJVMArgs.md](./RecommendedJVMArgs.md) for more details.
 ### nodeSelector
 
 Pega supports configuring certain nodes in your Kubernetes cluster with a label to identify its attributes, such as persistent storage. For such configurations, use the Pega Helm chart nodeSelector property to assign pods in a tier to run on particular nodes with a specified label. For more information about assigning Pods to Nodes including how to configure your Nodes with labels, see the [Kubernetes documentation on nodeSelector](https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector).

--- a/charts/pega/RecommendedJVMArgs.md
+++ b/charts/pega/RecommendedJVMArgs.md
@@ -1,0 +1,69 @@
+#### JVM Arguments for better tunability
+The following are the recommended arguments for better JVM tuning.
+
+**— JVM CodeCache**<br>
+CodeCache is the storage for JIT generated compiled code. If CodeCache is filled, compilation stops unless the code cache is flushed. <br>
+**Flag**: `-XX:+UseCodeCacheFlushing` <br>
+**Purpose**: Attempts to clean the CodeCache when filled, before stopping the compilation<br>
+**Defaults and Recommendation**: JVM default<br> 
+
+**Flag**: `-XX:InitialCodeCacheSize=SIZE` <br>
+**Purpose**: The initial value of the JVM CodeCache. Set this value to reasonable size to avoid overhead in dynamically increasing the cache.<br>
+**Defaults and Recommendation**:Set to `256M` for large scale deployments and JVM defaults for others.<br> 
+
+**Flag**: `-XX:+ReservedCodeCacheSize=SIZE` <br>
+**Purpose**: The maximum value the JVM CodeCache can grow, after which the cache is attempted to be flushed. <br>
+**Defaults and Recommendation**:Set to `512M` for large scale deployments and JVM defaults for others.<br> 
+
+**— JVM Metaspace** <br>
+Metaspace is a non-heap memory that stores the class metadata such as class structure, virtual method hierarchy, etc. 
+This is the Java8+ equivalent of *PermGen* space. This space is unbounded by default, in the sense that it can endlessly expand to the system Native space.<br>
+**Flag**: `-XX:MetaspaceSize=SIZE` <br>
+**Purpose**: This defines the initial size of Metaspace at which GC should be induced, expecting to clear up some Metaspace.
+ Note that this is *not* the initial size the metaspace is allocated. It is set just to avoid the early 'Metaspace induced GC'.<br>
+**Recommendation**: `512M` for large scale deployments and defaults for others.<br> 
+
+**Flag**: `-XX:MaxMetaspaceSize=SIZE` <br>
+**Purpose**: This is the maximum value the JVM Metaspace occupies. Beyond this "Metaspace OutOfMemoryError" is thrown.<br>
+**Defaults and Recommendation**: Unbounded, which is the JVM default value.<br>
+
+**Flag**: `-XX:+UseStringDeduplication` <br>
+**Purpose**: When multiple Java Strings have same literal value, these strings are duplicated. This flag deals with optimizing these duplications, maintaining a single String.<br>
+**Defaults and Recommendation**: Set to use the string deduplication. Tune this according to the needs.<br>
+
+**Flag**: `-XX:+DisableExplicitGC` <br>
+**Purpose**: Disables force GC, which can happen through external invocation of *System.gc()* calls.<br>
+**Defaults and Recommendation**: Set to disable explicit GC<br>
+**Note**: *This flag cannot be overridden through explicitly passing the flag*.
+
+**Flag**: `-Djava.security.egd=file:///dev/urandom` <br>
+**Purpose**: For non-bocking random number generation in case the entropy is exhausted.<br>
+**Defaults and Recommendation**: Set to use *urandom* <br>
+**Note**: *This flag cannot be overridden through explicitly passing the flag*.
+
+**Flag**: `-XX:+CrashOnOutOfMemoryError` <br>
+**Purpose**: When an OOME is occured, the thread in which the error occurs is terminated(if the error is not caught).
+  However, this leaves the JVM still running and in an inconsistent state. In this case, it's better to crash the JVM.<br>
+**Defaults and Recommendation**: Set to Crash the JVM in case of OOME<br>
+**Note**: *This flag cannot be overridden through explicitly passing the flag*.
+
+**Flag**: `-Xlog:gc*,gc+heap=debug,gc+humongous=debug:file=/usr/local/tomcat/logs/gc.log:uptime,pid,level,time,tags:filecount=3,filesize=2M` <br>
+**Purpose**: Dumps the GC logs with the provided tags into local log file. <br>
+**Recommendation**: Set to allow GC logs to be collected. Currently, the log rotation policy is set to 3 log files with maximum of 2MB each.<br>
+<br>
+##### Few more arguments:
+**Flag**: `-XX:MaxGCPauseMillis=n`<br>
+**Purpose**: Sets the peak pause time for GC to happen.<br>
+**Recommendation**: Set to higher value for BATCH pods for better throughput.
+<br>
+
+**Flag**: `-XX:StringTableSize=n`<br>
+**Purpose**: Sets the number of hash-buckets to be used in string pool for accommodating Strings<br>
+**Recommendation**: JVM default is 60013. Tune this based on requirements.<br>
+
+
+
+
+
+
+

--- a/charts/pega/RecommendedJVMArgs.md
+++ b/charts/pega/RecommendedJVMArgs.md
@@ -17,15 +17,15 @@ CodeCache is the storage for JIT generated compiled code. If CodeCache is filled
 Metaspace is a non-heap memory that stores the class metadata such as class structure, virtual method hierarchy, etc. 
 This is the Java8+ equivalent of *PermGen* space. This space is unbounded by default, in the sense that it can endlessly expand to the system Native space.<br>
 **Flag**: `-XX:MetaspaceSize=SIZE` <br>
-**Purpose**: Sets the initial size of Metaspace at which point the system induces Garbage Collection, in order to free Metaspace and prevent "Metaspace OutOfMemoryError". 
- Note that this is *not* the initial size the Metaspace is allocated. It is set just to avoid the early Metaspace induced GC.<br>
+**Purpose**: Sets the initial size of Metaspace at which point the JVM triggers Metaspace induced Garbage Collection (GC), in order to free Metaspace and prevent "Metaspace OutOfMemoryError".
+ This is *not* the minimum Metaspace allocated. The setting allows you to set a higher Metaspace trigger size in order to avoid an initial GC that may not be warranted when the deployment starts up. <br>
  **JVM default**: 20MB <br>
 **Recommendation**:Set to 512M for large scale deployments and JVM default for others.<br> 
 
 **Flag**: `-XX:MaxMetaspaceSize=SIZE` <br>
 **Purpose**: Sets the maximum value the JVM Metaspace can occupy. Beyond this "Metaspace OutOfMemoryError" is thrown.<br>
 **JVM default**: 18446744073709486080 Bytes or Unbounded <br>
-**Pega Recommendation**: Unbounded(default), to ensure that "Metaspace OutOfMemoryError" do not occur.<br>
+**Pega Recommendation**: Unbounded(default), to ensure that "Metaspace OutOfMemoryError" exceptions do not occur.<br>
 
 **Flag**: `-XX:+UseStringDeduplication` <br>
 **Purpose**: Maintains a single copy of String literals *aka Deduplication*, in case multiple Strings have the same literal value<br>

--- a/charts/pega/RecommendedJVMArgs.md
+++ b/charts/pega/RecommendedJVMArgs.md
@@ -9,7 +9,7 @@ CodeCache is the storage for JIT generated compiled code. If CodeCache is filled
 **Pega Recommendation**:Set to 256M for large scale deployments and JVM default for others.
 
 **Flag**: `-XX:ReservedCodeCacheSize=SIZE` <br>
-**Purpose**: Sets the maximum size upto which the JVM CodeCache can grow, after which the cache is attempted to be flushed. <br>
+**Purpose**: Sets the maximum size to which the JVM CodeCache can grow, after which the cache is attempted to be flushed. <br>
 **JVM default**: 250MB<br>
 **Pega Recommendation**:Set to 512M for large scale deployments and JVM default for others.<br> 
 
@@ -17,18 +17,18 @@ CodeCache is the storage for JIT generated compiled code. If CodeCache is filled
 Metaspace is a non-heap memory that stores the class metadata such as class structure, virtual method hierarchy, etc. 
 This is the Java8+ equivalent of *PermGen* space. This space is unbounded by default, in the sense that it can endlessly expand to the system Native space.<br>
 **Flag**: `-XX:MetaspaceSize=SIZE` <br>
-**Purpose**: Sets the initial size of Metaspace at which GC should be induced, expecting to clear up some Metaspace.
- Note that this is *not* the initial size the metaspace is allocated. It is set just to avoid the early Metaspace induced GC.<br>
+**Purpose**: Sets the initial size of Metaspace at which point the system induces Garbage Collection, in order to free Metaspace and prevent "Metaspace OutOfMemoryError". 
+ Note that this is *not* the initial size the Metaspace is allocated. It is set just to avoid the early Metaspace induced GC.<br>
  **JVM default**: 20MB <br>
 **Recommendation**:Set to 512M for large scale deployments and JVM default for others.<br> 
 
 **Flag**: `-XX:MaxMetaspaceSize=SIZE` <br>
 **Purpose**: Sets the maximum value the JVM Metaspace can occupy. Beyond this "Metaspace OutOfMemoryError" is thrown.<br>
 **JVM default**: 18446744073709486080 Bytes or Unbounded <br>
-**Pega Recommendation**: Unbounded, which is the JVM default value.<br>
+**Pega Recommendation**: Unbounded(default), to ensure that "Metaspace OutOfMemoryError" do not occur.<br>
 
 **Flag**: `-XX:+UseStringDeduplication` <br>
-**Purpose**: Maintains a single copy of String literals *aka Deduplication*, in case multiple Strings having same literal value<br>
+**Purpose**: Maintains a single copy of String literals *aka Deduplication*, in case multiple Strings have the same literal value<br>
 **JVM default**: *UseStringDeduplication=false* equivalent to `-XX:-UseStringDeduplication`<br>
 **Pega Recommendation**: Set to use the StringDeduplication.<br>
 
@@ -36,19 +36,19 @@ This is the Java8+ equivalent of *PermGen* space. This space is unbounded by def
 **Purpose**: Disables force GC, which can happen through external invocation of *System.gc()* call.<br>
 **JVM default**: *DisableExplicitGC=false* equivalent to `-XX:-DisableExplicitGC`<br>
 **Pega Recommendation**: Set to disable explicit GC<br>
-**Note**: *This flag cannot be overridden through explicitly passing the flag*.
+**Note**: *This JVM argument is hardcoded in the Docker image with the recommended value. You cannot explicitly overwrite this argument.*
 
 **Flag**: `-Djava.security.egd=file:///dev/urandom` <br>
-**Purpose**: Allows generation of random numbers in non-bocking mode, in case the entropy is exhausted.<br>
+**Purpose**: Allows generation of random numbers in non-blocking mode, in case the entropy is exhausted.<br>
 **JVM default**: *dev/random*<br>
 **Pega Recommendation**: Set to use *dev/urandom* <br>
-**Note**: *This flag cannot be overridden through explicitly passing the flag*.
+**Note**: *This JVM argument is hardcoded in the Docker image with the recommended value. You cannot explicitly overwrite this argument.*
 
 **Flag**: `-XX:+ExitOnOutOfMemoryError` <br>
-**Purpose**: Exits the JVM when an OutOfMemoryError occurs. Exiting is required, as allowing the JVM to run after OOME leads to inconsistent system state.<br>
+**Purpose**: Exits the JVM when an OutOfMemoryError occurs. Exiting is required, as allowing the JVM to run after OutOfMemoryError leads to inconsistent system state.<br>
 **JVM default**: *ExitOnOutOfMemoryError=false* equivalent to `-XX:-ExitOnOutOfMemoryError`<br>
-**Pega Recommendation**: Set to Exit the JVM in case of OOME <br>
-**Note**: *This flag cannot be overridden through explicitly passing the flag*.
+**Pega Recommendation**: Set to Exit the JVM in case of OutOfMemoryError <br>
+**Note**: *This JVM argument is hardcoded in the Docker image with the recommended value. You cannot explicitly overwrite this argument.*
 
 **Flag**: `-Xlog:gc*,gc+heap=debug,gc+humongous=debug:file=/usr/local/tomcat/logs/gc.log:uptime,pid,level,time,tags:filecount=3,filesize=2M` <br>
 **Purpose**: Dumps the GC logs with the provided tags into local log file. <br>
@@ -64,7 +64,7 @@ This is the Java8+ equivalent of *PermGen* space. This space is unbounded by def
 
 **Flag**: `-XX:StringTableSize=n`<br>
 **Purpose**: Sets the number of hash-buckets to be used in string pool for accommodating Strings<br>
-**JVM default**: 65536, the default Hash bucket size of JVM String pool <br>
+**JVM default**: 65536, the default Hash bucket size of the JVM String pool <br>
 **Pega Recommendation**: Tune this based on requirements.<br>
 
 

--- a/charts/pega/RecommendedJVMArgs.md
+++ b/charts/pega/RecommendedJVMArgs.md
@@ -2,64 +2,71 @@
 The following are the recommended arguments for better JVM tuning.
 
 **— JVM CodeCache**<br>
-CodeCache is the storage for JIT generated compiled code. If CodeCache is filled, compilation stops unless the code cache is flushed. <br>
-**Flag**: `-XX:+UseCodeCacheFlushing` <br>
-**Purpose**: Attempts to clean the CodeCache when filled, before stopping the compilation<br>
-**Defaults and Recommendation**: JVM default<br> 
-
+CodeCache is the storage for JIT generated compiled code. If CodeCache is filled, compilation is done unless the code cache is flushed. <br>
 **Flag**: `-XX:InitialCodeCacheSize=SIZE` <br>
-**Purpose**: The initial value of the JVM CodeCache. Set this value to reasonable size to avoid overhead in dynamically increasing the cache.<br>
-**Defaults and Recommendation**:Set to `256M` for large scale deployments and JVM defaults for others.<br> 
+**Purpose**: The initial value of the JVM CodeCache. Set this value to reasonable size to avoid dynamic adjustment overhead.<br>
+**JVM default**: 2555904 Bytes or around 2MB <br>
+**Pega Recommendation**:Set to 256M for large scale deployments and JVM default for others.
 
-**Flag**: `-XX:+ReservedCodeCacheSize=SIZE` <br>
+**Flag**: `-XX:ReservedCodeCacheSize=SIZE` <br>
 **Purpose**: The maximum value the JVM CodeCache can grow, after which the cache is attempted to be flushed. <br>
-**Defaults and Recommendation**:Set to `512M` for large scale deployments and JVM defaults for others.<br> 
+**JVM default**: 251658240Bytes or 250MB<br>
+**Pega Recommendation**:Set to 512M for large scale deployments and JVM default for others.<br> 
 
 **— JVM Metaspace** <br>
 Metaspace is a non-heap memory that stores the class metadata such as class structure, virtual method hierarchy, etc. 
 This is the Java8+ equivalent of *PermGen* space. This space is unbounded by default, in the sense that it can endlessly expand to the system Native space.<br>
 **Flag**: `-XX:MetaspaceSize=SIZE` <br>
-**Purpose**: This defines the initial size of Metaspace at which GC should be induced, expecting to clear up some Metaspace.
- Note that this is *not* the initial size the metaspace is allocated. It is set just to avoid the early 'Metaspace induced GC'.<br>
-**Recommendation**: `512M` for large scale deployments and defaults for others.<br> 
+**Purpose**: This defines the initial size of Metaspace at which GC should be induced expecting to clear up some Metaspace.
+ Note that this is *not* the initial size the metaspace is allocated. It is set just to avoid the early Metaspace induced GC.<br>
+ **JVM default**: 21807104Bytes or around 20MB <br>
+**Recommendation**:Set to 512M for large scale deployments and JVM default for others.<br> 
 
 **Flag**: `-XX:MaxMetaspaceSize=SIZE` <br>
 **Purpose**: This is the maximum value the JVM Metaspace occupies. Beyond this "Metaspace OutOfMemoryError" is thrown.<br>
-**Defaults and Recommendation**: Unbounded, which is the JVM default value.<br>
+**JVM default**: 18446744073709486080Bytes or Unbounded <br>
+**Pega Recommendation**: Unbounded, which is the JVM default value.<br>
 
 **Flag**: `-XX:+UseStringDeduplication` <br>
-**Purpose**: When multiple Java Strings have same literal value, these strings are duplicated. This flag deals with optimizing these duplications, maintaining a single String.<br>
-**Defaults and Recommendation**: Set to use the string deduplication. Tune this according to the needs.<br>
+**Purpose**: When multiple Java Strings have same literal value, these strings are duplicated. This flag deals with optimizing these duplications.<br>
+**JVM default**: *UseStringDeduplication=false* equivalent to `-XX:-UseStringDeduplication`<br>
+**Pega Recommendation**: Set to use the StringDeduplication.<br>
 
 **Flag**: `-XX:+DisableExplicitGC` <br>
-**Purpose**: Disables force GC, which can happen through external invocation of *System.gc()* calls.<br>
-**Defaults and Recommendation**: Set to disable explicit GC<br>
+**Purpose**: Disables force GC, which can happen through external invocation of *System.gc()* call.<br>
+**JVM default**: *DisableExplicitGC=false* equivalent to `-XX:-DisableExplicitGC`<br>
+**Pega Recommendation**: Set to disable explicit GC<br>
 **Note**: *This flag cannot be overridden through explicitly passing the flag*.
 
 **Flag**: `-Djava.security.egd=file:///dev/urandom` <br>
 **Purpose**: For non-bocking random number generation in case the entropy is exhausted.<br>
-**Defaults and Recommendation**: Set to use *urandom* <br>
+**JVM default**: *dev/random*<br>
+**Pega Recommendation**: Set to use *dev/urandom* <br>
 **Note**: *This flag cannot be overridden through explicitly passing the flag*.
 
-**Flag**: `-XX:+CrashOnOutOfMemoryError` <br>
+**Flag**: `-XX:+ExitOnOutOfMemoryError` <br>
 **Purpose**: When an OOME is occured, the thread in which the error occurs is terminated(if the error is not caught).
-  However, this leaves the JVM still running and in an inconsistent state. In this case, it's better to crash the JVM.<br>
-**Defaults and Recommendation**: Set to Crash the JVM in case of OOME<br>
+  However, this leaves the JVM still running and in an inconsistent state. In this case, it's better to exit the JVM.<br>
+**JVM default**: *ExitOnOutOfMemoryError=false* equivalent to `-XX:-ExitOnOutOfMemoryError`<br>
+**Pega Recommendation**: Set to Exit the JVM in case of OOME <br>
 **Note**: *This flag cannot be overridden through explicitly passing the flag*.
 
 **Flag**: `-Xlog:gc*,gc+heap=debug,gc+humongous=debug:file=/usr/local/tomcat/logs/gc.log:uptime,pid,level,time,tags:filecount=3,filesize=2M` <br>
 **Purpose**: Dumps the GC logs with the provided tags into local log file. <br>
-**Recommendation**: Set to allow GC logs to be collected. Currently, the log rotation policy is set to 3 log files with maximum of 2MB each.<br>
+**JVM default**: No GC logs will be emitted by default.<br>
+**Pega Recommendation**: Set to allow GC logs to be collected. Currently, the log rotation policy is set to 3 log files with maximum of 2MB each.<br>
 <br>
 ##### Few more arguments:
 **Flag**: `-XX:MaxGCPauseMillis=n`<br>
 **Purpose**: Sets the peak pause time for GC to happen.<br>
-**Recommendation**: Set to higher value for BATCH pods for better throughput.
+**JVM default**: 200 milliseconds<br>
+**Pega Recommendation**: Set to higher value for BATCH pods for better throughput.
 <br>
 
 **Flag**: `-XX:StringTableSize=n`<br>
 **Purpose**: Sets the number of hash-buckets to be used in string pool for accommodating Strings<br>
-**Recommendation**: JVM default is 60013. Tune this based on requirements.<br>
+**JVM default**: 65536 <br>
+**Pega Recommendation**: Tune this based on requirements.<br>
 
 
 

--- a/charts/pega/RecommendedJVMArgs.md
+++ b/charts/pega/RecommendedJVMArgs.md
@@ -4,31 +4,31 @@ The following are the recommended arguments for better JVM tuning.
 **— JVM CodeCache**<br>
 CodeCache is the storage for JIT generated compiled code. If CodeCache is filled, compilation is done unless the code cache is flushed. <br>
 **Flag**: `-XX:InitialCodeCacheSize=SIZE` <br>
-**Purpose**: The initial value of the JVM CodeCache. Set this value to reasonable size to avoid dynamic adjustment overhead.<br>
-**JVM default**: 2555904 Bytes or around 2MB <br>
+**Purpose**: Sets the initial size of the JVM CodeCache. Set this to a reasonable size to avoid dynamic adjustment overhead.<br>
+**JVM default**: 2MB <br>
 **Pega Recommendation**:Set to 256M for large scale deployments and JVM default for others.
 
 **Flag**: `-XX:ReservedCodeCacheSize=SIZE` <br>
-**Purpose**: The maximum value the JVM CodeCache can grow, after which the cache is attempted to be flushed. <br>
-**JVM default**: 251658240Bytes or 250MB<br>
+**Purpose**: Sets the maximum size upto which the JVM CodeCache can grow, after which the cache is attempted to be flushed. <br>
+**JVM default**: 250MB<br>
 **Pega Recommendation**:Set to 512M for large scale deployments and JVM default for others.<br> 
 
 **— JVM Metaspace** <br>
 Metaspace is a non-heap memory that stores the class metadata such as class structure, virtual method hierarchy, etc. 
 This is the Java8+ equivalent of *PermGen* space. This space is unbounded by default, in the sense that it can endlessly expand to the system Native space.<br>
 **Flag**: `-XX:MetaspaceSize=SIZE` <br>
-**Purpose**: This defines the initial size of Metaspace at which GC should be induced expecting to clear up some Metaspace.
+**Purpose**: Sets the initial size of Metaspace at which GC should be induced, expecting to clear up some Metaspace.
  Note that this is *not* the initial size the metaspace is allocated. It is set just to avoid the early Metaspace induced GC.<br>
- **JVM default**: 21807104Bytes or around 20MB <br>
+ **JVM default**: 20MB <br>
 **Recommendation**:Set to 512M for large scale deployments and JVM default for others.<br> 
 
 **Flag**: `-XX:MaxMetaspaceSize=SIZE` <br>
-**Purpose**: This is the maximum value the JVM Metaspace occupies. Beyond this "Metaspace OutOfMemoryError" is thrown.<br>
-**JVM default**: 18446744073709486080Bytes or Unbounded <br>
+**Purpose**: Sets the maximum value the JVM Metaspace can occupy. Beyond this "Metaspace OutOfMemoryError" is thrown.<br>
+**JVM default**: 18446744073709486080 Bytes or Unbounded <br>
 **Pega Recommendation**: Unbounded, which is the JVM default value.<br>
 
 **Flag**: `-XX:+UseStringDeduplication` <br>
-**Purpose**: When multiple Java Strings have same literal value, these strings are duplicated. This flag deals with optimizing these duplications.<br>
+**Purpose**: Maintains a single copy of String literals *aka Deduplication*, in case multiple Strings having same literal value<br>
 **JVM default**: *UseStringDeduplication=false* equivalent to `-XX:-UseStringDeduplication`<br>
 **Pega Recommendation**: Set to use the StringDeduplication.<br>
 
@@ -39,14 +39,13 @@ This is the Java8+ equivalent of *PermGen* space. This space is unbounded by def
 **Note**: *This flag cannot be overridden through explicitly passing the flag*.
 
 **Flag**: `-Djava.security.egd=file:///dev/urandom` <br>
-**Purpose**: For non-bocking random number generation in case the entropy is exhausted.<br>
+**Purpose**: Allows generation of random numbers in non-bocking mode, in case the entropy is exhausted.<br>
 **JVM default**: *dev/random*<br>
 **Pega Recommendation**: Set to use *dev/urandom* <br>
 **Note**: *This flag cannot be overridden through explicitly passing the flag*.
 
 **Flag**: `-XX:+ExitOnOutOfMemoryError` <br>
-**Purpose**: When an OOME is occured, the thread in which the error occurs is terminated(if the error is not caught).
-  However, this leaves the JVM still running and in an inconsistent state. In this case, it's better to exit the JVM.<br>
+**Purpose**: Exits the JVM when an OutOfMemoryError occurs. Exiting is required, as allowing the JVM to run after OOME leads to inconsistent system state.<br>
 **JVM default**: *ExitOnOutOfMemoryError=false* equivalent to `-XX:-ExitOnOutOfMemoryError`<br>
 **Pega Recommendation**: Set to Exit the JVM in case of OOME <br>
 **Note**: *This flag cannot be overridden through explicitly passing the flag*.
@@ -65,7 +64,7 @@ This is the Java8+ equivalent of *PermGen* space. This space is unbounded by def
 
 **Flag**: `-XX:StringTableSize=n`<br>
 **Purpose**: Sets the number of hash-buckets to be used in string pool for accommodating Strings<br>
-**JVM default**: 65536 <br>
+**JVM default**: 65536, the default Hash bucket size of JVM String pool <br>
 **Pega Recommendation**: Tune this based on requirements.<br>
 
 

--- a/charts/pega/templates/_helpers.tpl
+++ b/charts/pega/templates/_helpers.tpl
@@ -132,7 +132,11 @@ until cqlsh -u {{ $cassandraUser | quote }} -p {{ $cassandraPassword | quote }} 
   value: "{{ .node.javaOpts }}"
 # Additional CATALINA arguments
 - name: CATALINA_OPTS
+{{- if .node.catalinaOpts }}
   value: "{{ .node.catalinaOpts }}"
+{{- else }}
+  value: ""
+{{- end }}
 # Initial JVM heap size, equivalent to -Xms
 - name: INITIAL_HEAP
 {{- if .node.initialHeap }}

--- a/charts/pega/templates/_helpers.tpl
+++ b/charts/pega/templates/_helpers.tpl
@@ -130,6 +130,9 @@ until cqlsh -u {{ $cassandraUser | quote }} -p {{ $cassandraPassword | quote }} 
 # Additional JVM arguments
 - name: JAVA_OPTS
   value: "{{ .node.javaOpts }}"
+# Additional CATALINA arguments
+- name: CATALINA_OPTS
+  value: "{{ .node.catalinaOpts }}"
 # Initial JVM heap size, equivalent to -Xms
 - name: INITIAL_HEAP
 {{- if .node.initialHeap }}

--- a/charts/pega/values-large.yaml
+++ b/charts/pega/values-large.yaml
@@ -104,6 +104,8 @@ global:
 
       replicas: 1
       javaOpts: ""
+      # Check the 'JVM Arguments' section in https://github.com/pegasystems/pega-helm-charts/blob/master/charts/pega/README.md
+      catalinaOpts: "-XX:InitialCodeCacheSize=256M -XX:ReservedCodeCacheSize=512M -XX:MetaspaceSize=512M"
       pegaDiagnosticUser: ""
       pegaDiagnosticPassword: ""
 

--- a/terratest/src/test/pega/pega-tier-deployment_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment_test.go
@@ -142,6 +142,9 @@ func VerifyDeployment(t *testing.T, pod *k8score.PodSpec, expectedSpec pegaDeplo
 	require.Equal(t, pod.Containers[0].Env[envIndex].Name, "JAVA_OPTS")
 	require.Equal(t, pod.Containers[0].Env[envIndex].Value, "")
 	envIndex++
+	require.Equal(t, pod.Containers[0].Env[envIndex].Name, "CATALINA_OPTS")
+    require.Equal(t, pod.Containers[0].Env[envIndex].Value, "")
+    envIndex++
 	require.Equal(t, pod.Containers[0].Env[envIndex].Name, "INITIAL_HEAP")
 	require.Equal(t, pod.Containers[0].Env[envIndex].Value, "4096m")
 	envIndex++


### PR DESCRIPTION
For better tunability of JVM Pega recommends defaults for some of the JVM arguments. Any JVM arguments with the flexibility to override can be provided as **catalinaOpts** under a specified tier. Note that _some_ of the arguments don't have the flexibility to be overridden and hence are defaulted in Docker image. This is complemented by related changes for **CATALINA_OPTS** in https://github.com/pegasystems/docker-pega-web-ready image. 
Link to the mentioned PR: https://github.com/pegasystems/docker-pega-web-ready/pull/95

