### PR TITLE
Fix indexing of the backing services file name

### DIFF
--- a/before_deploy.sh
+++ b/before_deploy.sh
@@ -6,7 +6,7 @@ export CHART_VERSION=$(expr ${TRAVIS_TAG:1})
 export PEGA_FILE_NAME=pega-${CHART_VERSION}.tgz
 export ADDONS_FILE_NAME=addons-${CHART_VERSION}.tgz
 export BACKINGSERVICES_FILE_NAME=backingservices-${CHART_VERSION}.tgz
-cat descriptor-template.json | jq '.files[0].includePattern=env.PEGA_FILE_NAME' | jq '.files[0].uploadPattern=env.PEGA_FILE_NAME' | jq '.files[1].includePattern=env.ADDONS_FILE_NAME' | jq '.files[1].uploadPattern=env.ADDONS_FILE_NAME' | jq '.files[1].includePattern=env.BACKINGSERVICES_FILE_NAME' | jq '.files[1].uploadPattern=env.BACKINGSERVICES_FILE_NAME' > descriptor.json
+cat descriptor-template.json | jq '.files[0].includePattern=env.PEGA_FILE_NAME' | jq '.files[0].uploadPattern=env.PEGA_FILE_NAME' | jq '.files[1].includePattern=env.ADDONS_FILE_NAME' | jq '.files[1].uploadPattern=env.ADDONS_FILE_NAME' | jq '.files[2].includePattern=env.BACKINGSERVICES_FILE_NAME' | jq '.files[2].uploadPattern=env.BACKINGSERVICES_FILE_NAME' > descriptor.json
 curl -o index.yaml https://dl.bintray.com/pegasystems/pega-helm-charts/index.yaml
 helm package --version ${CHART_VERSION} ./charts/pega/
 helm package --version ${CHART_VERSION} ./charts/addons/


### PR DESCRIPTION
As reported in #234 we are no longer publishing the addons file.  It appears that this may be caused by `before_deploy.sh` applying the same index to both addons and then backingservices to replace the descriptor-template.json with the actual file names.

This PR attempts to fix the publishing of the addons chart by updating the before deploy script with a proper index for the backing services tgz.