### PR TITLE
added .custom.sidecarContainers to use sidecar Containers

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -466,6 +466,21 @@ tier:
       serviceAccountName: MY_SERVICE_ACCOUNT_NAME
 ```
 
+### Sidecar Containers
+
+If the pod needs to run with one or more [sidecar containers](https://kubernetes.io/docs/concepts/cluster-administration/logging/#using-a-sidecar-container-with-the-logging-agent), you can specify custom  'sidecarContainers' for your deployment tier.
+
+Example:
+
+```yaml
+tier:
+  - name: my-tier
+    custom:
+      sidecarContainers:
+      - name: SIDECAR_NAME
+        image: SIDECAR_IMAGE_URL
+```
+
 ### Custom Annotations for Pods
 
 You may optionally provide custom annotations for Pods as metadata to be consumed by other tools and libraries. Pod annotations may be specified by using the `podAnnotations` element for a given `tier`.

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -88,6 +88,12 @@ spec:
 {{- end }}
 {{- end }}
       containers:
+{{- if .custom }}
+{{- if .custom.sidecarContainers }}
+        # Additional custom sidecar containers
+{{ toYaml .custom.sidecarContainers | indent 6 }}
+{{- end }}
+{{- end }}      
       # Name of the container
       - name: pega-web-tomcat
         # The pega image, you may use the official pega distribution or you may extend


### PR DESCRIPTION
I've added a .custom.sidecarContainers annotation and also updated the readme file with an example. We use this sidecar container configuration to have a shared volume mount on which the pega container writes its logging. the rsyslog sidecar container then copies this logging and sends it to an ELK-stack which is hosted elsewhere.