### PR TITLE
ISSUE-240:Turning off Reverse DNS lookup

### DIFF
--- a/charts/pega/config/deploy/prconfig.xml
+++ b/charts/pega/config/deploy/prconfig.xml
@@ -7,6 +7,7 @@
         <env name="database/databases/PegaDATA/dataSource" value="java:comp/env/jdbc/PegaRULES"/>
         <env name="security/urlaccesslog" value="NORMAL" />
         <env name="security/urlaccessmode" value="WARN" />
+        <env name="http/reversednslookup" value="false" />​
         <!-- Most nodes have a 'default' classification and for these nodes, no additional changes need to be made to this file.  However,
         if this is node has a non-general purpose, for example: 'Agent', then the node classification setting should be added to this file. -->
         <!--env name="initialization/nodeclassification" value="Agent" /  -->

--- a/terratest/src/test/pega/data/expectedInstallDeployPrconfig.xml
+++ b/terratest/src/test/pega/data/expectedInstallDeployPrconfig.xml
@@ -7,6 +7,7 @@
         <env name="database/databases/PegaDATA/dataSource" value="java:comp/env/jdbc/PegaRULES"/>
         <env name="security/urlaccesslog" value="NORMAL" />
         <env name="security/urlaccessmode" value="WARN" />
+        <env name="http/reversednslookup" value="false" />​
         <!-- Most nodes have a 'default' classification and for these nodes, no additional changes need to be made to this file.  However,
         if this is node has a non-general purpose, for example: 'Agent', then the node classification setting should be added to this file. -->
         <!--env name="initialization/nodeclassification" value="Agent" /  -->


### PR DESCRIPTION
Reverse DNS is used to lookup the hostname of the IP address where the request is originating from. This is typically used for logging purposes, so domain names can be shown instead of IP addresses. However, this doesn't make sense in cloud and/or cluster deployments, since the originating IP address will be an internal address, e.g. the address of the load balancer etc. Since doing a reverse DNS will not provide any value, it will result in unneeded overhead.
 Reverse DNS lookups have also been shown to be a source of spikes, in case the DNS server / resolver get into temporarily non-responsive.
Regarding backward compatibility: Since its main purpose is logging, there shoudn't be any b/w compatibility issues.