### PR TITLE
BUG-629910 SRS service http port mapping to 80

### DIFF
--- a/charts/backingservices/charts/srs/templates/srsservice_service.yaml
+++ b/charts/backingservices/charts/srs/templates/srsservice_service.yaml
@@ -16,4 +16,8 @@ spec:
       port: 8080
       protocol: TCP
       targetPort: 8080
+    - name: http80
+      port: 80
+      protocol: TCP
+      targetPort: 8080
 {{ end }}

--- a/terratest/src/test/backingservices/srs-service_test.go
+++ b/terratest/src/test/backingservices/srs-service_test.go
@@ -54,6 +54,9 @@ func VerifySRSService(t *testing.T, serviceObj *k8score.Service) {
 	require.Equal(t, "rest", serviceObj.Spec.Ports[0].Name)
 	require.Equal(t, int32(8080), serviceObj.Spec.Ports[0].Port)
 	require.Equal(t, intstr.FromInt(8080), serviceObj.Spec.Ports[0].TargetPort)
+	require.Equal(t, "http80", serviceObj.Spec.Ports[1].Name)
+	require.Equal(t, int32(80), serviceObj.Spec.Ports[1].Port)
+	require.Equal(t, intstr.FromInt(8080), serviceObj.Spec.Ports[1].TargetPort)
 }
 
 func VerifySRSServiceWithEgress(t *testing.T, serviceObj *k8score.Service) {
@@ -62,4 +65,7 @@ func VerifySRSServiceWithEgress(t *testing.T, serviceObj *k8score.Service) {
 	require.Equal(t, "rest", serviceObj.Spec.Ports[0].Name)
 	require.Equal(t, int32(8080), serviceObj.Spec.Ports[0].Port)
 	require.Equal(t, intstr.FromInt(8080), serviceObj.Spec.Ports[0].TargetPort)
+	require.Equal(t, "http80", serviceObj.Spec.Ports[1].Name)
+	require.Equal(t, int32(80), serviceObj.Spec.Ports[1].Port)
+	require.Equal(t, intstr.FromInt(8080), serviceObj.Spec.Ports[1].TargetPort)
 }


### PR DESCRIPTION
Bug identified with service availability on port 8080 only. The documentation does not specify port 8080 and should be accessible using http://srs-service-name