### PR TITLE
Add opt-in ReadOnly datasource to context.xml template

### DIFF
--- a/charts/pega/config/deploy/context.xml.tmpl
+++ b/charts/pega/config/deploy/context.xml.tmpl
@@ -53,4 +53,9 @@
   {{ if .Env.REQUESTOR_PASSIVATION_TIMEOUT }}
   <Environment name="prconfig/timeout/browser" value="{{ .Env.REQUESTOR_PASSIVATION_TIMEOUT }}" type="java.lang.String" />
   {{ end }}
+
+  {{ if .Env.CONTEXT_XML_SNIPPET }}
+  {{ .Env.CONTEXT_XML_SNIPPET }}
+  {{ end }}
+
 </Context>

--- a/charts/pega/config/deploy/context.xml.tmpl
+++ b/charts/pega/config/deploy/context.xml.tmpl
@@ -17,7 +17,29 @@
     maxWaitMillis="{{ .Env.JDBC_MAX_WAIT }}"
     initialSize="{{ .Env.JDBC_INITIAL_SIZE }}"
     connectionProperties="{{ .Env.JDBC_CONNECTION_PROPERTIES }}"
-  />
+    />
+  {{ if .Env.JDBC_RO_URL }}
+    <Resource name="jdbc/PegaRULESReadOnly"
+    auth="Container"
+    type="javax.sql.DataSource"
+    driverClassName="{{ .Env.JDBC_CLASS }}"
+    url="{{ .Env.JDBC_RO_URL }}"
+    username="{{ .Env.DB_RO_USERNAME }}"
+    password="{{ .Env.DB_RO_PASSWORD }}"
+    maxTotal="{{ .Env.JDBC_MAX_ACTIVE }}"
+    minIdle="{{ .Env.JDBC_MIN_IDLE }}"
+    maxIdle="{{ .Env.JDBC_MAX_IDLE }}"
+    maxWaitMillis="{{ .Env.JDBC_MAX_WAIT }}"
+    initialSize="{{ .Env.JDBC_INITIAL_SIZE }}"
+    connectionProperties="{{ .Env.JDBC_CONNECTION_PROPERTIES }}"
+    />
+  
+  <Environment name="prconfig/database/databases/PegaRULES/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly"/>
+  <Environment name="prconfig/database/databases/PegaDATA/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly"/>
+  {{ if .Env.CUSTOMERDATA_SCHEMA }}
+  <Environment name="prconfig/database/databases/PegaRULES/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly"/>
+  {{ end }}
+  {{ end }}
 
   <Environment name="url/initialization/explicittempdir" value="path" type="java.lang.String"/>
   <Environment name="prconfig/database/databases/PegaRULES/defaultSchema" value="{{ .Env.RULES_SCHEMA }}" type="java.lang.String" />

--- a/charts/pega/config/deploy/context.xml.tmpl
+++ b/charts/pega/config/deploy/context.xml.tmpl
@@ -18,7 +18,7 @@
     initialSize="{{ .Env.JDBC_INITIAL_SIZE }}"
     connectionProperties="{{ .Env.JDBC_CONNECTION_PROPERTIES }}"
     />
-  {{ if .Env.JDBC_RO_URL }}
+  {{ if and .Env.JDBC_RO_URL .Env.DB_RO_USERNAME .Env.DB_RO_PASSWORD }}
     <Resource name="jdbc/PegaRULESReadOnly"
     auth="Container"
     type="javax.sql.DataSource"
@@ -34,10 +34,10 @@
     connectionProperties="{{ .Env.JDBC_CONNECTION_PROPERTIES }}"
     />
   
-  <Environment name="prconfig/database/databases/PegaRULES/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly"/>
-  <Environment name="prconfig/database/databases/PegaDATA/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly"/>
+  <Environment name="prconfig/database/databases/PegaRULES/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly" type="java.lang.String" />
+  <Environment name="prconfig/database/databases/PegaDATA/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly" type="java.lang.String" />
   {{ if .Env.CUSTOMERDATA_SCHEMA }}
-  <Environment name="prconfig/database/databases/PegaRULES/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly"/>
+  <Environment name="prconfig/database/databases/CustomerData/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly" type="java.lang.String" />
   {{ end }}
   {{ end }}
 

--- a/charts/pega/templates/pega-environment-config.yaml
+++ b/charts/pega/templates/pega-environment-config.yaml
@@ -10,6 +10,10 @@ data:
   DB_TYPE: {{ .Values.global.jdbc.dbType }}
   # JDBC URL of the DB where Pega is installed
   JDBC_URL: {{ .Values.global.jdbc.url }}
+{{- if .Values.global.jdbc.readerurl }}
+  # URI that the JDBC driver can be downloaded from
+  JDBC_RO_URL: {{ .Values.global.jdbc.readerurl }}
+{{- end }}
   # Class name of the DB's JDBC driver
   JDBC_CLASS: {{ .Values.global.jdbc.driverClass }}
 {{- if .Values.global.jdbc.driverUri }}

--- a/charts/pega/templates/pega-environment-config.yaml
+++ b/charts/pega/templates/pega-environment-config.yaml
@@ -11,7 +11,7 @@ data:
   # JDBC URL of the DB where Pega is installed
   JDBC_URL: {{ .Values.global.jdbc.url }}
 {{- if .Values.global.jdbc.readerurl }}
-  # URI that the JDBC driver can be downloaded from
+  # JDBC URL to configure Read Only Datasource
   JDBC_RO_URL: {{ .Values.global.jdbc.readerurl }}
 {{- end }}
   # Class name of the DB's JDBC driver

--- a/terratest/src/test/pega/data/expectedInstallDeployContext.xml
+++ b/terratest/src/test/pega/data/expectedInstallDeployContext.xml
@@ -17,7 +17,29 @@
     maxWaitMillis="{{ .Env.JDBC_MAX_WAIT }}"
     initialSize="{{ .Env.JDBC_INITIAL_SIZE }}"
     connectionProperties="{{ .Env.JDBC_CONNECTION_PROPERTIES }}"
-  />
+    />
+  {{ if and .Env.JDBC_RO_URL .Env.DB_RO_USERNAME .Env.DB_RO_PASSWORD }}
+    <Resource name="jdbc/PegaRULESReadOnly"
+    auth="Container"
+    type="javax.sql.DataSource"
+    driverClassName="{{ .Env.JDBC_CLASS }}"
+    url="{{ .Env.JDBC_RO_URL }}"
+    username="{{ .Env.DB_RO_USERNAME }}"
+    password="{{ .Env.DB_RO_PASSWORD }}"
+    maxTotal="{{ .Env.JDBC_MAX_ACTIVE }}"
+    minIdle="{{ .Env.JDBC_MIN_IDLE }}"
+    maxIdle="{{ .Env.JDBC_MAX_IDLE }}"
+    maxWaitMillis="{{ .Env.JDBC_MAX_WAIT }}"
+    initialSize="{{ .Env.JDBC_INITIAL_SIZE }}"
+    connectionProperties="{{ .Env.JDBC_CONNECTION_PROPERTIES }}"
+    />
+  
+  <Environment name="prconfig/database/databases/PegaRULES/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly" type="java.lang.String" />
+  <Environment name="prconfig/database/databases/PegaDATA/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly" type="java.lang.String" />
+  {{ if .Env.CUSTOMERDATA_SCHEMA }}
+  <Environment name="prconfig/database/databases/CustomerData/dataSourceReadOnly" value="java:comp/env/jdbc/PegaRULESReadOnly" type="java.lang.String" />
+  {{ end }}
+  {{ end }}
 
   <Environment name="url/initialization/explicittempdir" value="path" type="java.lang.String"/>
   <Environment name="prconfig/database/databases/PegaRULES/defaultSchema" value="{{ .Env.RULES_SCHEMA }}" type="java.lang.String" />

--- a/terratest/src/test/pega/data/expectedInstallDeployContext.xml
+++ b/terratest/src/test/pega/data/expectedInstallDeployContext.xml
@@ -53,4 +53,9 @@
   {{ if .Env.REQUESTOR_PASSIVATION_TIMEOUT }}
   <Environment name="prconfig/timeout/browser" value="{{ .Env.REQUESTOR_PASSIVATION_TIMEOUT }}" type="java.lang.String" />
   {{ end }}
+
+  {{ if .Env.CONTEXT_XML_SNIPPET }}
+  {{ .Env.CONTEXT_XML_SNIPPET }}
+  {{ end }}
+
 </Context>


### PR DESCRIPTION
RO datasource is added with presence of new global.jdbc.readerurl value, and configured with RO env var credentials. This is to support [QueryRunner](https://community.pega.com/knowledgebase/articles/pega-cloud/query-runner-landing-page-testing-select-statements)