### PR TITLE
Adjust chart memory limits to mitigate oom risk

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -361,8 +361,8 @@ Parameter       | Description                                            | Defau
 `replicas`      | Specify the number of Pods to deploy in the tier.      | `1`
 `cpuRequest`    | Initial CPU request for pods in the current tier.      | `2`
 `cpuLimit`      | CPU limit for pods in the current tier.                | `4`
-`memRequest`    | Initial memory request for pods in the current tier.   | `10Gi`
-`memLimit`      | Memory limit for pods in the current tier.             | `10Gi`
+`memRequest`    | Initial memory request for pods in the current tier.   | `12Gi`
+`memLimit`      | Memory limit for pods in the current tier.             | `12Gi`
 `initialHeap`   | This specifies the initial heap size of the JVM.       | `4096m`
 `maxHeap`       | This specifies the maximum heap size of the JVM.       | `8192m`
 

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -363,8 +363,8 @@ Parameter       | Description                                            | Defau
 `cpuLimit`      | CPU limit for pods in the current tier.                | `4`
 `memRequest`    | Initial memory request for pods in the current tier.   | `12Gi`
 `memLimit`      | Memory limit for pods in the current tier.             | `12Gi`
-`initialHeap`   | This specifies the initial heap size of the JVM.       | `4096m`
-`maxHeap`       | This specifies the maximum heap size of the JVM.       | `8192m`
+`initialHeap`   | Specify the initial heap size of the JVM               | `4096m`
+`maxHeap`       | Specify the maximum heap size of the JVM               | `8192m`
 
 ### JVM Arguments
 You can optionally pass in JVM arguments to Tomcat.  Depending on the parameter/attribute used, the arguments will be placed into `JAVA_OPTS` or `CATALINA_OPTS` environmental variables.

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -356,15 +356,16 @@ ingress:
 
 You can optionally configure the resource allocation and limits for a tier using the following parameters. The default value is used if you do not specify an alternative value. See [Managing Kubernetes Resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) for more information about how Kubernetes manages resources.
 
-Parameter       | Description    | Default value
----             | ---       | ---
-`replicas`      | Specify the number of Pods to deploy in the tier. | `1`
-`cpuRequest`    | Initial CPU request for pods in the current tier.  | `2`
-`cpuLimit`      | CPU limit for pods in the current tier.  | `4`
-`memRequest`    | Initial memory request for pods in the current tier. | `6Gi`
-`memLimit`      | Memory limit for pods in the current tier. | `8Gi`
-`initialHeap`   | This specifies the initial heap size of the JVM.  | `4096m`
-`maxHeap`       | This specifies the maximum heap size of the JVM.  | `7168m`
+Parameter       | Description                                            | Default value
+---             | ---                                                    | ---
+`replicas`      | Specify the number of Pods to deploy in the tier.      | `1`
+`cpuRequest`    | Initial CPU request for pods in the current tier.      | `2`
+`cpuLimit`      | CPU limit for pods in the current tier.                | `4`
+`memRequest`    | Initial memory request for pods in the current tier.   | `10Gi`
+`memLimit`      | Memory limit for pods in the current tier.             | `10Gi`
+`initialHeap`   | This specifies the initial heap size of the JVM.       | `4096m`
+`maxHeap`       | This specifies the maximum heap size of the JVM.       | `8192m`
+`maxMetaspace`  | This specifies the maximum metaspace size of the JVM.  | `1024m`
 
 ### JVM Arguments
 You can optionally pass in JVM arguments to Tomcat.  Depending on the parameter/attribute used, the arguments will be placed into `JAVA_OPTS` or `CATALINA_OPTS` environmental variables.

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -365,7 +365,6 @@ Parameter       | Description                                            | Defau
 `memLimit`      | Memory limit for pods in the current tier.             | `10Gi`
 `initialHeap`   | This specifies the initial heap size of the JVM.       | `4096m`
 `maxHeap`       | This specifies the maximum heap size of the JVM.       | `8192m`
-`maxMetaspace`  | This specifies the maximum metaspace size of the JVM.  | `1024m`
 
 ### JVM Arguments
 You can optionally pass in JVM arguments to Tomcat.  Depending on the parameter/attribute used, the arguments will be placed into `JAVA_OPTS` or `CATALINA_OPTS` environmental variables.

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -363,8 +363,8 @@ Parameter       | Description                                            | Defau
 `cpuLimit`      | CPU limit for pods in the current tier.                | `4`
 `memRequest`    | Initial memory request for pods in the current tier.   | `12Gi`
 `memLimit`      | Memory limit for pods in the current tier.             | `12Gi`
-`initialHeap`   | Specify the initial heap size of the JVM               | `4096m`
-`maxHeap`       | Specify the maximum heap size of the JVM               | `8192m`
+`initialHeap`   | Specify the initial heap size of the JVM.              | `4096m`
+`maxHeap`       | Specify the maximum heap size of the JVM.              | `8192m`
 
 ### JVM Arguments
 You can optionally pass in JVM arguments to Tomcat.  Depending on the parameter/attribute used, the arguments will be placed into `JAVA_OPTS` or `CATALINA_OPTS` environmental variables.

--- a/charts/pega/templates/_helpers.tpl
+++ b/charts/pega/templates/_helpers.tpl
@@ -149,7 +149,7 @@ until cqlsh -u {{ $cassandraUser | quote }} -p {{ $cassandraPassword | quote }} 
 {{- if .node.maxHeap }}
   value: "{{ .node.maxHeap }}"
 {{- else }}
-  value: "7168m"
+  value: "8192m"
 {{- end }}
 {{- end -}}
 

--- a/charts/pega/templates/_helpers.tpl
+++ b/charts/pega/templates/_helpers.tpl
@@ -151,13 +151,6 @@ until cqlsh -u {{ $cassandraUser | quote }} -p {{ $cassandraPassword | quote }} 
 {{- else }}
   value: "8192m"
 {{- end }}
-# Maximum JVM metaspace, equivalent to XX:MaxMetaspaceSize
-- name: MAX_METASPACE
-{{- if .node.maxMetaspace }}
-  value: "{{ .node.maxMetaspace }}"
-{{- else }}
-  value: "1024m"
-{{- end }}
 {{- end -}}
 
 # Evaluate background node types based on cassandra enabled or not(internally or externally)

--- a/charts/pega/templates/_helpers.tpl
+++ b/charts/pega/templates/_helpers.tpl
@@ -151,6 +151,13 @@ until cqlsh -u {{ $cassandraUser | quote }} -p {{ $cassandraPassword | quote }} 
 {{- else }}
   value: "8192m"
 {{- end }}
+# Maximum JVM metaspace, equivalent to XX:MaxMetaspaceSize
+- name: MAX_METASPACE
+{{- if .node.maxMetaspace }}
+  value: "{{ .node.maxMetaspace }}"
+{{- else }}
+  value: "1024m"
+{{- end }}
 {{- end -}}
 
 # Evaluate background node types based on cassandra enabled or not(internally or externally)

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -152,7 +152,7 @@ spec:
           {{- if .node.memLimit }}
             memory: "{{ .node.memLimit }}"
           {{- else }}
-            memory: "10Gi"
+            memory: "12Gi"
           {{- end }}
           # CPU and Memory that the containers for {{ .name }} request
           requests:
@@ -164,7 +164,7 @@ spec:
           {{- if .node.memRequest }}
             memory: "{{ .node.memRequest }}"
           {{- else }}
-            memory: "10Gi"
+            memory: "12Gi"
           {{- end }}
         volumeMounts:
         # The given mountpath is mapped to volume with the specified name.  The config map files are mounted here.

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -152,7 +152,7 @@ spec:
           {{- if .node.memLimit }}
             memory: "{{ .node.memLimit }}"
           {{- else }}
-            memory: "8Gi"
+            memory: "10Gi"
           {{- end }}
           # CPU and Memory that the containers for {{ .name }} request
           requests:
@@ -164,7 +164,7 @@ spec:
           {{- if .node.memRequest }}
             memory: "{{ .node.memRequest }}"
           {{- else }}
-            memory: "6Gi"
+            memory: "10Gi"
           {{- end }}
         volumeMounts:
         # The given mountpath is mapped to volume with the specified name.  The config map files are mounted here.

--- a/charts/pega/values-minimal.yaml
+++ b/charts/pega/values-minimal.yaml
@@ -74,7 +74,7 @@ global:
       # Set resource consumption to minimal levels
       replicas: 1
       cpuRequest: 200m
-      memRequest: "5Gi"
+      memRequest: "6Gi"
       cpuLimit: 2
       memLimit: "6Gi"
       javaOpts: ""

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -108,9 +108,9 @@ global:
 
       # Optionally overridde default resource specifications
       # cpuRequest: 2
-      # memRequest: "10Gi"
+      # memRequest: "12Gi"
       # cpuLimit: 4
-      # memLimit: "10Gi"
+      # memLimit: "12Gi"
       # initialHeap: "4096m"
       # maxHeap: "8192m"
 

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -113,7 +113,6 @@ global:
       # memLimit: "10Gi"
       # initialHeap: "4096m"
       # maxHeap: "8192m"
-      # maxMetaspace: "1024m"
 
       # To configure an alternative user for custom image, set value for runAsUser.
       # See, https://github.com/pegasystems/pega-helm-charts/blob/master/charts/pega/README.md#security-context

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -108,11 +108,12 @@ global:
 
       # Optionally overridde default resource specifications
       # cpuRequest: 2
-      # memRequest: "6Gi"
+      # memRequest: "10Gi"
       # cpuLimit: 4
-      # memLimit: "8Gi"
+      # memLimit: "10Gi"
       # initialHeap: "4096m"
-      # maxHeap: "7168m"
+      # maxHeap: "8192m"
+      # maxMetaspace: "1024m"
 
       # To configure an alternative user for custom image, set value for runAsUser.
       # See, https://github.com/pegasystems/pega-helm-charts/blob/master/charts/pega/README.md#security-context

--- a/terratest/src/test/pega/data/pega-tier-config-override_values.yaml
+++ b/terratest/src/test/pega/data/pega-tier-config-override_values.yaml
@@ -108,9 +108,9 @@ global:
 
       # Optionally overridde default resource specifications
       # cpuRequest: 2
-      # memRequest: "10Gi"
+      # memRequest: "12Gi"
       # cpuLimit: 4
-      # memLimit: "10Gi"
+      # memLimit: "12Gi"
       # initialHeap: "4096m"
       # maxHeap: "8192m"
 

--- a/terratest/src/test/pega/data/pega-tier-config-override_values.yaml
+++ b/terratest/src/test/pega/data/pega-tier-config-override_values.yaml
@@ -113,7 +113,6 @@ global:
       # memLimit: "10Gi"
       # initialHeap: "4096m"
       # maxHeap: "8192m"
-      # maxMetaspace: "1024m"
 
       # To configure an alternative user for custom image, set value for runAsUser.
       # See, https://github.com/pegasystems/pega-helm-charts/blob/master/charts/pega/README.md#security-context

--- a/terratest/src/test/pega/data/pega-tier-config-override_values.yaml
+++ b/terratest/src/test/pega/data/pega-tier-config-override_values.yaml
@@ -108,11 +108,12 @@ global:
 
       # Optionally overridde default resource specifications
       # cpuRequest: 2
-      # memRequest: "6Gi"
+      # memRequest: "10Gi"
       # cpuLimit: 4
-      # memLimit: "8Gi"
+      # memLimit: "10Gi"
       # initialHeap: "4096m"
-      # maxHeap: "7168m"
+      # maxHeap: "8192m"
+      # maxMetaspace: "1024m"
 
       # To configure an alternative user for custom image, set value for runAsUser.
       # See, https://github.com/pegasystems/pega-helm-charts/blob/master/charts/pega/README.md#security-context

--- a/terratest/src/test/pega/data/values_gke_managedcertificate.yaml
+++ b/terratest/src/test/pega/data/values_gke_managedcertificate.yaml
@@ -109,11 +109,12 @@ global:
 
       # Optionally overridde default resource specifications
       # cpuRequest: 2
-      # memRequest: "6Gi"
+      # memRequest: "10Gi"
       # cpuLimit: 4
-      # memLimit: "8Gi"
+      # memLimit: "10Gi"
       # initialHeap: "4096m"
-      # maxHeap: "7168m"
+      # maxHeap: "8192m"
+      # maxMetaspace: "1024m"
 
       hpa:
         enabled: true

--- a/terratest/src/test/pega/data/values_gke_managedcertificate.yaml
+++ b/terratest/src/test/pega/data/values_gke_managedcertificate.yaml
@@ -109,9 +109,9 @@ global:
 
       # Optionally overridde default resource specifications
       # cpuRequest: 2
-      # memRequest: "10Gi"
+      # memRequest: "12Gi"
       # cpuLimit: 4
-      # memLimit: "10Gi"
+      # memLimit: "12Gi"
       # initialHeap: "4096m"
       # maxHeap: "8192m"
 

--- a/terratest/src/test/pega/data/values_gke_managedcertificate.yaml
+++ b/terratest/src/test/pega/data/values_gke_managedcertificate.yaml
@@ -114,7 +114,6 @@ global:
       # memLimit: "10Gi"
       # initialHeap: "4096m"
       # maxHeap: "8192m"
-      # maxMetaspace: "1024m"
 
       hpa:
         enabled: true

--- a/terratest/src/test/pega/pega-tier-deployment_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment_test.go
@@ -1,99 +1,94 @@
 package pega
 
 import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
 	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
 	appsv1beta2 "k8s.io/api/apps/v1beta2"
 	k8score "k8s.io/api/core/v1"
 	intstr "k8s.io/apimachinery/pkg/util/intstr"
-	"path/filepath"
-	"strings"
-	"testing"
-	"fmt"
 )
-
 
 var initContainers = []string{"wait-for-pegasearch", "wait-for-cassandra"}
 
-func TestPegaTierDeployment(t *testing.T){
-	var supportedVendors = []string{"k8s","openshift","eks","gke","aks","pks"}
-	var supportedOperations =  []string{"deploy","install-deploy","upgrade-deploy"}
+func TestPegaTierDeployment(t *testing.T) {
+	var supportedVendors = []string{"k8s", "openshift", "eks", "gke", "aks", "pks"}
+	var supportedOperations = []string{"deploy", "install-deploy", "upgrade-deploy"}
 
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
+	for _, vendor := range supportedVendors {
 
-	for _,vendor := range supportedVendors{
-
-		for _,operation := range supportedOperations{
+		for _, operation := range supportedOperations {
 
 			fmt.Println(vendor + "-" + operation)
 
-			var options = &helm.Options{			
+			var options = &helm.Options{
 				SetValues: map[string]string{
 					"global.provider":        vendor,
 					"global.actions.execute": operation,
-			 	},
-		    }
+				},
+			}
 
 			yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
-			yamlSplit := strings.Split(yamlContent, "---")			
-			assertWeb(t,yamlSplit[1],options)
-			assertBatch(t,yamlSplit[2],options)
-			assertStream(t,yamlSplit[3],options)
+			yamlSplit := strings.Split(yamlContent, "---")
+			assertWeb(t, yamlSplit[1], options)
+			assertBatch(t, yamlSplit[2], options)
+			assertStream(t, yamlSplit[3], options)
 
 		}
 	}
 }
 
-func assertStream(t *testing.T, streamYaml string, options *helm.Options){
+func assertStream(t *testing.T, streamYaml string, options *helm.Options) {
 	var statefulsetObj appsv1beta2.StatefulSet
-	UnmarshalK8SYaml(t,streamYaml,&statefulsetObj)
-	VerifyPegaStatefulSet(t, &statefulsetObj, pegaDeployment{"pega-stream", initContainers, "Stream", "900"},options)
+	UnmarshalK8SYaml(t, streamYaml, &statefulsetObj)
+	VerifyPegaStatefulSet(t, &statefulsetObj, pegaDeployment{"pega-stream", initContainers, "Stream", "900"}, options)
 }
 
-
-
-func assertBatch(t *testing.T, batchYaml string, options *helm.Options){
+func assertBatch(t *testing.T, batchYaml string, options *helm.Options) {
 	var deploymentObj appsv1.Deployment
-	UnmarshalK8SYaml(t,batchYaml,&deploymentObj)
+	UnmarshalK8SYaml(t, batchYaml, &deploymentObj)
 	VerifyPegaDeployment(t, &deploymentObj,
 		pegaDeployment{"pega-batch", initContainers, "BackgroundProcessing,Search,Batch,RealTime,Custom1,Custom2,Custom3,Custom4,Custom5,BIX", ""},
 		options)
-	
+
 }
 
-func assertWeb(t *testing.T, webYaml string, options *helm.Options){
+func assertWeb(t *testing.T, webYaml string, options *helm.Options) {
 	var deploymentObj appsv1.Deployment
-	UnmarshalK8SYaml(t,webYaml,&deploymentObj)
+	UnmarshalK8SYaml(t, webYaml, &deploymentObj)
 	VerifyPegaDeployment(t, &deploymentObj, pegaDeployment{"pega-web", initContainers, "WebUser", "900"}, options)
-	
-	
+
 }
 
 // VerifyPegaStatefulSet - Performs specific Pega statefulset assertions with the values as provided in default values.yaml
 func VerifyPegaStatefulSet(t *testing.T, statefulsetObj *appsv1beta2.StatefulSet, expectedStatefulset pegaDeployment, options *helm.Options) {
-	require.Equal(t, statefulsetObj.Spec.VolumeClaimTemplates[0].Name, "pega-stream")
-	require.Equal(t, statefulsetObj.Spec.VolumeClaimTemplates[0].Spec.AccessModes[0], k8score.PersistentVolumeAccessMode("ReadWriteOnce"))
-	require.Equal(t, statefulsetObj.Spec.ServiceName, "pega-stream")
+	require.Equal(t, "pega-stream", statefulsetObj.Spec.VolumeClaimTemplates[0].Name)
+	require.Equal(t, k8score.PersistentVolumeAccessMode("ReadWriteOnce"), statefulsetObj.Spec.VolumeClaimTemplates[0].Spec.AccessModes[0])
+	require.Equal(t, "pega-stream", statefulsetObj.Spec.ServiceName)
 	statefulsetSpec := statefulsetObj.Spec.Template.Spec
-	require.Equal(t, statefulsetSpec.Containers[0].VolumeMounts[1].Name, "pega-stream")
-	require.Equal(t, statefulsetSpec.Containers[0].VolumeMounts[1].MountPath, "/opt/pega/kafkadata")
-	require.Equal(t, statefulsetSpec.Containers[0].VolumeMounts[2].Name, "pega-volume-credentials")
-	require.Equal(t, statefulsetSpec.Containers[0].VolumeMounts[2].MountPath, "/opt/pega/secrets")
+	require.Equal(t, "pega-stream", statefulsetSpec.Containers[0].VolumeMounts[1].Name)
+	require.Equal(t, "/opt/pega/kafkadata", statefulsetSpec.Containers[0].VolumeMounts[1].MountPath)
+	require.Equal(t, "pega-volume-credentials", statefulsetSpec.Containers[0].VolumeMounts[2].Name)
+	require.Equal(t, "/opt/pega/secrets", statefulsetSpec.Containers[0].VolumeMounts[2].MountPath)
 	VerifyDeployment(t, &statefulsetSpec, expectedStatefulset, options)
 }
 
-
 // VerifyPegaDeployment - Performs specific Pega deployment assertions with the values as provided in default values.yaml
 func VerifyPegaDeployment(t *testing.T, deploymentObj *appsv1.Deployment, expectedDeployment pegaDeployment, options *helm.Options) {
-	require.Equal(t, *deploymentObj.Spec.Replicas, int32(1))
-	require.Equal(t, *deploymentObj.Spec.ProgressDeadlineSeconds, int32(2147483647))
+	require.Equal(t, int32(1), *deploymentObj.Spec.Replicas)
+	require.Equal(t, int32(2147483647), *deploymentObj.Spec.ProgressDeadlineSeconds)
 	require.Equal(t, expectedDeployment.name, deploymentObj.Spec.Selector.MatchLabels["app"])
-	require.Equal(t, *deploymentObj.Spec.Strategy.RollingUpdate.MaxSurge, intstr.FromString("25%"))
-	require.Equal(t, *deploymentObj.Spec.Strategy.RollingUpdate.MaxUnavailable, intstr.FromString("25%"))
-	require.Equal(t, deploymentObj.Spec.Strategy.Type, appsv1.DeploymentStrategyType("RollingUpdate"))
+	require.Equal(t, intstr.FromString("25%"), *deploymentObj.Spec.Strategy.RollingUpdate.MaxSurge)
+	require.Equal(t, intstr.FromString("25%"), *deploymentObj.Spec.Strategy.RollingUpdate.MaxUnavailable)
+	require.Equal(t, appsv1.DeploymentStrategyType("RollingUpdate"), deploymentObj.Spec.Strategy.Type)
 	require.Equal(t, expectedDeployment.name, deploymentObj.Spec.Template.Labels["app"])
 	require.NotEmpty(t, deploymentObj.Spec.Template.Annotations["config-check"])
 	deploymentSpec := deploymentObj.Spec.Template.Spec
@@ -102,12 +97,12 @@ func VerifyPegaDeployment(t *testing.T, deploymentObj *appsv1.Deployment, expect
 
 // VerifyDeployment - Performs common pega deployment/statefulset assertions with the values as provided in default values.yaml
 func VerifyDeployment(t *testing.T, pod *k8score.PodSpec, expectedSpec pegaDeployment, options *helm.Options) {
-	require.Equal(t, pod.Volumes[0].Name, "pega-volume-config")
+	require.Equal(t, "pega-volume-config", pod.Volumes[0].Name)
 	require.Equal(t, expectedSpec.name, pod.Volumes[0].VolumeSource.ConfigMap.LocalObjectReference.Name)
-	require.Equal(t, pod.Volumes[0].VolumeSource.ConfigMap.DefaultMode, volumeDefaultModePtr)
-	require.Equal(t, pod.Volumes[1].Name, "pega-volume-credentials")
-	require.Equal(t, pod.Volumes[1].VolumeSource.Secret.SecretName, "pega-credentials-secret")
-	require.Equal(t, pod.Volumes[1].VolumeSource.Secret.DefaultMode, volumeDefaultModePtr)
+	require.Equal(t, volumeDefaultModePtr, pod.Volumes[0].VolumeSource.ConfigMap.DefaultMode)
+	require.Equal(t, "pega-volume-credentials", pod.Volumes[1].Name)
+	require.Equal(t, "pega-credentials-secret", pod.Volumes[1].VolumeSource.Secret.SecretName)
+	require.Equal(t, volumeDefaultModePtr, pod.Volumes[1].VolumeSource.Secret.DefaultMode)
 
 	actualInitContainers := pod.InitContainers
 	count := len(actualInitContainers)
@@ -118,73 +113,73 @@ func VerifyDeployment(t *testing.T, pod *k8score.PodSpec, expectedSpec pegaDeplo
 
 	//require.Equal(t, expectedSpec.initContainers, actualInitContainerNames) NEED TO CHANGE FOR "install-deploy"
 	VerifyInitContinerData(t, actualInitContainers, options)
-	require.Equal(t, pod.Containers[0].Name, "pega-web-tomcat")
-	require.Equal(t, pod.Containers[0].Image, "pegasystems/pega")
-	require.Equal(t, pod.Containers[0].Ports[0].Name, "pega-web-port")
-	require.Equal(t, pod.Containers[0].Ports[0].ContainerPort, int32(8080))
+	require.Equal(t, "pega-web-tomcat", pod.Containers[0].Name)
+	require.Equal(t, "pegasystems/pega", pod.Containers[0].Image)
+	require.Equal(t, "pega-web-port", pod.Containers[0].Ports[0].Name)
+	require.Equal(t, int32(8080), pod.Containers[0].Ports[0].ContainerPort)
 	var envIndex int32 = 0
-	require.Equal(t, pod.Containers[0].Env[envIndex].Name, "NODE_TYPE")
+	require.Equal(t, "NODE_TYPE", pod.Containers[0].Env[envIndex].Name)
 	require.Equal(t, expectedSpec.nodeType, pod.Containers[0].Env[envIndex].Value)
 	envIndex++
-	require.Equal(t, pod.Containers[0].Env[envIndex].Name, "PEGA_APP_CONTEXT_PATH")
-	require.Equal(t, pod.Containers[0].Env[envIndex].Value, "prweb")
+	require.Equal(t, "PEGA_APP_CONTEXT_PATH", pod.Containers[0].Env[envIndex].Name)
+	require.Equal(t, "prweb", pod.Containers[0].Env[envIndex].Value)
 	if expectedSpec.name == "pega-web" || expectedSpec.name == "pega-stream" {
 		envIndex++
-		require.Equal(t, pod.Containers[0].Env[envIndex].Name, "REQUESTOR_PASSIVATION_TIMEOUT")
+		require.Equal(t, "REQUESTOR_PASSIVATION_TIMEOUT", pod.Containers[0].Env[envIndex].Name)
 		require.Equal(t, expectedSpec.passivationTimeout, pod.Containers[0].Env[envIndex].Value)
 	}
 	if options.SetValues["constellation.enabled"] == "true" {
 		envIndex++
-		require.Equal(t, pod.Containers[0].Env[envIndex].Name, "COSMOS_SETTINGS")
+		require.Equal(t, "COSMOS_SETTINGS", pod.Containers[0].Env[envIndex].Name)
 		require.Equal(t, "Pega-UIEngine/cosmosservicesURI=/c11n", pod.Containers[0].Env[envIndex].Value)
 	}
 	envIndex++
-	require.Equal(t, pod.Containers[0].Env[envIndex].Name, "JAVA_OPTS")
-	require.Equal(t, pod.Containers[0].Env[envIndex].Value, "")
+	require.Equal(t, "JAVA_OPTS", pod.Containers[0].Env[envIndex].Name)
+	require.Equal(t, "", pod.Containers[0].Env[envIndex].Value)
 	envIndex++
-	require.Equal(t, pod.Containers[0].Env[envIndex].Name, "CATALINA_OPTS")
-    require.Equal(t, pod.Containers[0].Env[envIndex].Value, "")
-    envIndex++
-	require.Equal(t, pod.Containers[0].Env[envIndex].Name, "INITIAL_HEAP")
-	require.Equal(t, pod.Containers[0].Env[envIndex].Value, "4096m")
+	require.Equal(t, "CATALINA_OPTS", pod.Containers[0].Env[envIndex].Name)
+	require.Equal(t, "", pod.Containers[0].Env[envIndex].Value)
 	envIndex++
-	require.Equal(t, pod.Containers[0].Env[envIndex].Name, "MAX_HEAP")
-	require.Equal(t, pod.Containers[0].Env[envIndex].Value, "7168m")
-	require.Equal(t, pod.Containers[0].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name, "pega-environment-config")
+	require.Equal(t, "INITIAL_HEAP", pod.Containers[0].Env[envIndex].Name)
+	require.Equal(t, "4096m", pod.Containers[0].Env[envIndex].Value)
+	envIndex++
+	require.Equal(t, "MAX_HEAP", pod.Containers[0].Env[envIndex].Name)
+	require.Equal(t, "8192m", pod.Containers[0].Env[envIndex].Value)
+	require.Equal(t, "pega-environment-config", pod.Containers[0].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name)
 	require.Equal(t, "4", pod.Containers[0].Resources.Limits.Cpu().String())
-	require.Equal(t, "8Gi", pod.Containers[0].Resources.Limits.Memory().String())
+	require.Equal(t, "10Gi", pod.Containers[0].Resources.Limits.Memory().String())
 	require.Equal(t, "2", pod.Containers[0].Resources.Requests.Cpu().String())
-	require.Equal(t, "6Gi", pod.Containers[0].Resources.Requests.Memory().String())
+	require.Equal(t, "10Gi", pod.Containers[0].Resources.Requests.Memory().String())
 
-	require.Equal(t, pod.Containers[0].VolumeMounts[0].Name, "pega-volume-config")
-	require.Equal(t, pod.Containers[0].VolumeMounts[0].MountPath, "/opt/pega/config")
+	require.Equal(t, "pega-volume-config", pod.Containers[0].VolumeMounts[0].Name)
+	require.Equal(t, "/opt/pega/config", pod.Containers[0].VolumeMounts[0].MountPath)
 
-	require.Equal(t, pod.Containers[0].LivenessProbe.InitialDelaySeconds, int32(300))
-	require.Equal(t, pod.Containers[0].LivenessProbe.TimeoutSeconds, int32(20))
-	require.Equal(t, pod.Containers[0].LivenessProbe.PeriodSeconds, int32(30))
-	require.Equal(t, pod.Containers[0].LivenessProbe.SuccessThreshold, int32(1))
-	require.Equal(t, pod.Containers[0].LivenessProbe.FailureThreshold, int32(3))
-	require.Equal(t, pod.Containers[0].LivenessProbe.HTTPGet.Path, "/prweb/PRRestService/monitor/pingService/ping")
-	require.Equal(t, pod.Containers[0].LivenessProbe.HTTPGet.Port, intstr.FromInt(8080))
-	require.Equal(t, pod.Containers[0].LivenessProbe.HTTPGet.Scheme, k8score.URIScheme("HTTP"))
+	require.Equal(t, int32(300), pod.Containers[0].LivenessProbe.InitialDelaySeconds)
+	require.Equal(t, int32(20), pod.Containers[0].LivenessProbe.TimeoutSeconds)
+	require.Equal(t, int32(30), pod.Containers[0].LivenessProbe.PeriodSeconds)
+	require.Equal(t, int32(1), pod.Containers[0].LivenessProbe.SuccessThreshold)
+	require.Equal(t, int32(3), pod.Containers[0].LivenessProbe.FailureThreshold)
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/ping", pod.Containers[0].LivenessProbe.HTTPGet.Path)
+	require.Equal(t, intstr.FromInt(8080), pod.Containers[0].LivenessProbe.HTTPGet.Port)
+	require.Equal(t, k8score.URIScheme("HTTP"), pod.Containers[0].LivenessProbe.HTTPGet.Scheme)
 
-	require.Equal(t, pod.Containers[0].ReadinessProbe.InitialDelaySeconds, int32(300))
-	require.Equal(t, pod.Containers[0].ReadinessProbe.TimeoutSeconds, int32(20))
-	require.Equal(t, pod.Containers[0].ReadinessProbe.PeriodSeconds, int32(30))
-	require.Equal(t, pod.Containers[0].ReadinessProbe.SuccessThreshold, int32(1))
-	require.Equal(t, pod.Containers[0].ReadinessProbe.FailureThreshold, int32(3))
-	require.Equal(t, pod.Containers[0].ReadinessProbe.HTTPGet.Path, "/prweb/PRRestService/monitor/pingService/ping")
-	require.Equal(t, pod.Containers[0].ReadinessProbe.HTTPGet.Port, intstr.FromInt(8080))
-	require.Equal(t, pod.Containers[0].ReadinessProbe.HTTPGet.Scheme, k8score.URIScheme("HTTP"))
+	require.Equal(t, int32(300), pod.Containers[0].ReadinessProbe.InitialDelaySeconds)
+	require.Equal(t, int32(20), pod.Containers[0].ReadinessProbe.TimeoutSeconds)
+	require.Equal(t, int32(30), pod.Containers[0].ReadinessProbe.PeriodSeconds)
+	require.Equal(t, int32(1), pod.Containers[0].ReadinessProbe.SuccessThreshold)
+	require.Equal(t, int32(3), pod.Containers[0].ReadinessProbe.FailureThreshold)
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/ping", pod.Containers[0].ReadinessProbe.HTTPGet.Path)
+	require.Equal(t, intstr.FromInt(8080), pod.Containers[0].ReadinessProbe.HTTPGet.Port)
+	require.Equal(t, k8score.URIScheme("HTTP"), pod.Containers[0].ReadinessProbe.HTTPGet.Scheme)
 
-	require.Equal(t, pod.ImagePullSecrets[0].Name, "pega-registry-secret")
-	require.Equal(t, pod.RestartPolicy, k8score.RestartPolicy("Always"))
-	require.Equal(t, *pod.TerminationGracePeriodSeconds, int64(300))
-	require.Equal(t, pod.Containers[0].VolumeMounts[0].Name, "pega-volume-config")
-	require.Equal(t, pod.Containers[0].VolumeMounts[0].MountPath, "/opt/pega/config")
-	require.Equal(t, pod.Volumes[0].Name, "pega-volume-config")
-	require.Equal(t, pod.Volumes[1].Name, "pega-volume-credentials")
-	require.Equal(t, pod.Volumes[1].Secret.SecretName, "pega-credentials-secret")
+	require.Equal(t, "pega-registry-secret", pod.ImagePullSecrets[0].Name)
+	require.Equal(t, k8score.RestartPolicy("Always"), pod.RestartPolicy)
+	require.Equal(t, int64(300), *pod.TerminationGracePeriodSeconds)
+	require.Equal(t, "pega-volume-config", pod.Containers[0].VolumeMounts[0].Name)
+	require.Equal(t, "/opt/pega/config", pod.Containers[0].VolumeMounts[0].MountPath)
+	require.Equal(t, "pega-volume-config", pod.Volumes[0].Name)
+	require.Equal(t, "pega-volume-credentials", pod.Volumes[1].Name)
+	require.Equal(t, "pega-credentials-secret", pod.Volumes[1].Secret.SecretName)
 
 }
 

--- a/terratest/src/test/pega/pega-tier-deployment_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment_test.go
@@ -147,9 +147,9 @@ func VerifyDeployment(t *testing.T, pod *k8score.PodSpec, expectedSpec pegaDeplo
 	require.Equal(t, "8192m", pod.Containers[0].Env[envIndex].Value)
 	require.Equal(t, "pega-environment-config", pod.Containers[0].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name)
 	require.Equal(t, "4", pod.Containers[0].Resources.Limits.Cpu().String())
-	require.Equal(t, "10Gi", pod.Containers[0].Resources.Limits.Memory().String())
+	require.Equal(t, "12Gi", pod.Containers[0].Resources.Limits.Memory().String())
 	require.Equal(t, "2", pod.Containers[0].Resources.Requests.Cpu().String())
-	require.Equal(t, "10Gi", pod.Containers[0].Resources.Requests.Memory().String())
+	require.Equal(t, "12Gi", pod.Containers[0].Resources.Requests.Memory().String())
 
 	require.Equal(t, "pega-volume-config", pod.Containers[0].VolumeMounts[0].Name)
 	require.Equal(t, "/opt/pega/config", pod.Containers[0].VolumeMounts[0].MountPath)

--- a/terratest/src/test/pega/pega-tier-deployment_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment_test.go
@@ -145,6 +145,9 @@ func VerifyDeployment(t *testing.T, pod *k8score.PodSpec, expectedSpec pegaDeplo
 	envIndex++
 	require.Equal(t, "MAX_HEAP", pod.Containers[0].Env[envIndex].Name)
 	require.Equal(t, "8192m", pod.Containers[0].Env[envIndex].Value)
+	envIndex++
+	require.Equal(t, "MAX_METASPACE", pod.Containers[0].Env[envIndex].Name)
+	require.Equal(t, "1024m", pod.Containers[0].Env[envIndex].Value)
 	require.Equal(t, "pega-environment-config", pod.Containers[0].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name)
 	require.Equal(t, "4", pod.Containers[0].Resources.Limits.Cpu().String())
 	require.Equal(t, "10Gi", pod.Containers[0].Resources.Limits.Memory().String())

--- a/terratest/src/test/pega/pega-tier-deployment_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment_test.go
@@ -145,9 +145,6 @@ func VerifyDeployment(t *testing.T, pod *k8score.PodSpec, expectedSpec pegaDeplo
 	envIndex++
 	require.Equal(t, "MAX_HEAP", pod.Containers[0].Env[envIndex].Name)
 	require.Equal(t, "8192m", pod.Containers[0].Env[envIndex].Value)
-	envIndex++
-	require.Equal(t, "MAX_METASPACE", pod.Containers[0].Env[envIndex].Name)
-	require.Equal(t, "1024m", pod.Containers[0].Env[envIndex].Value)
 	require.Equal(t, "pega-environment-config", pod.Containers[0].EnvFrom[0].ConfigMapRef.LocalObjectReference.Name)
 	require.Equal(t, "4", pod.Containers[0].Resources.Limits.Cpu().String())
 	require.Equal(t, "10Gi", pod.Containers[0].Resources.Limits.Memory().String())


### PR DESCRIPTION
Adjust the JVM and container memory settings to reduce the risk of inadvertently exceeding the container memory limit.