### PR TITLE
Issue #270 Don't swap the 8080 port in a patch release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: python
 os: linux
-dist: xenial
+dist: bionic
 env:
   global:
     - HELM_URL=https://get.helm.sh
@@ -14,6 +14,7 @@ install:
   - PATH=`pwd`/linux-amd64/:$PATH
   # Install YamlLint
   - sudo pip install yamllint=="${YAMLLINT_VERSION}"
+  - nvm install --lts
   - npm install -g --save remark-cli to-vfile remark-preset-lint-recommended remark-validate-links remark-lint-no-dead-urls remark-message-control remark-preset-lint-markdown-style-guide remark-lint
   # Install Go
   - eval "$(gimme 1.13.1)"

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -188,7 +188,7 @@ spec:
         livenessProbe:
           httpGet:
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/ping"
-            port: 8081
+            port: 8080
             scheme: HTTP
           initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds | default 0 }}
           timeoutSeconds: {{ $livenessProbe.timeoutSeconds | default 20 }}
@@ -225,7 +225,7 @@ spec:
         livenessProbe:
           httpGet:
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/ping"
-            port: 8081
+            port: 8080
             scheme: HTTP
           initialDelaySeconds: {{ $livenessProbe.initialDelaySeconds | default 200 }}
           timeoutSeconds: {{ $livenessProbe.timeoutSeconds | default 20 }}

--- a/terratest/src/test/pega/pega-tier-deployment_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment_test.go
@@ -163,7 +163,7 @@ func VerifyDeployment(t *testing.T, pod *k8score.PodSpec, expectedSpec pegaDeplo
 	require.Equal(t, int32(1), pod.Containers[0].LivenessProbe.SuccessThreshold)
 	require.Equal(t, int32(3), pod.Containers[0].LivenessProbe.FailureThreshold)
 	require.Equal(t, "/prweb/PRRestService/monitor/pingService/ping", pod.Containers[0].LivenessProbe.HTTPGet.Path)
-	require.Equal(t, intstr.FromInt(8081), pod.Containers[0].LivenessProbe.HTTPGet.Port)
+	require.Equal(t, intstr.FromInt(8080), pod.Containers[0].LivenessProbe.HTTPGet.Port)
 	require.Equal(t, k8score.URIScheme("HTTP"), pod.Containers[0].LivenessProbe.HTTPGet.Scheme)
 
 	require.Equal(t, int32(30), pod.Containers[0].ReadinessProbe.InitialDelaySeconds)


### PR DESCRIPTION
Resolves #270 

The port change to 8081 should not have been made in a patch release in combination with the ability to update server.xml.

Use 8080 and release a new patch release to resolve the issue, then follow up after with a new minor version for 8081 which also details the minimum docker-pega-web-ready image requirements.