### PR TITLE
Run as restricted user

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -34,9 +34,7 @@ install           | Install Pega Platform into your database without deploying.
 install-deploy    | Install Pega Platform into your database and then deploy.
 upgrade           | Upgrade or patch Pega Platform in your database without deploying.
 upgrade-deploy    | Upgrade or patch Pega Platform in your database and then deploy.
-<!--upgrade           | Upgrade the Pega Platform installation in your database.
-upgrade-deploy    | Upgrade the Pega Platform installation in your database, and then deploy.
--->
+
 Example:
 
 ```yaml

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -141,6 +141,17 @@ You may opt to run Pega with a linux user whose permissions are constrained at a
 runWithRestrictedUserPermissions: "true"
 ```
 
+### Running with Restricted Privileges on Openshift
+
+The Openshift platform contains additional default security features that will prevent the proper function of this feature.  It is generally recommended that Openshift users leverage Openshift's OOTB security features, but it is possible to configure Openshift and the Pega Helm Charts to use it.
+
+To leverage the this feature on Openshift:
+1. Set the `runWithRestrictedUserPermissions` to `true` as above.
+2. Create a service account for the Pega deployment: `oc create serviceaccount pega`.
+3. Allow this service account `anyuid` scc access: `oc adm policy add-scc-to-user anyuid -z pega --as system:admin` (requires admin access).
+4. For each Pega tier defined under `global.tier`, add a `custom.serviceAccountName` to `pega`.
+5. Perform `helm install` 
+
 ## Tiers of a Pega deployment
 
 Pega supports deployment using a multi-tier architecture to separate processing and functions. Isolating processing in its own tier also allows for unique deployment configuration such as its own prconfig, resource allocations, or scaling characteristics.  Use the `tier` section in the helm chart to specify which tiers you wish to deploy and their logical tasks.  

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -133,6 +133,14 @@ docker:
     imagePullPolicy: "Always"
 ```
 
+## Running Pega With Restricted Privileges
+
+You may opt to run Pega with a linux user whose permissions are constrained at an operating system level.  This is currently an opt-in feature.  Set the `global.runWithRestrictedUserPermissions` to true to enable this feature.
+
+```yaml
+runWithRestrictedUserPermissions: "true"
+```
+
 ## Tiers of a Pega deployment
 
 Pega supports deployment using a multi-tier architecture to separate processing and functions. Isolating processing in its own tier also allows for unique deployment configuration such as its own prconfig, resource allocations, or scaling characteristics.  Use the `tier` section in the helm chart to specify which tiers you wish to deploy and their logical tasks.  

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -78,7 +78,7 @@ spec:
       nodeSelector:
 {{ toYaml .node.nodeSelector | indent 8 }}
 {{- end }}
-{{- if or (ne .root.Values.global.provider "openshift") (.root.Values.global.runWithRestrictedUserPermissions) }}
+{{- if or (ne .root.Values.global.provider "openshift") (coalesce .root.Values.global.runWithRestrictedUserPermissions false) }}
       securityContext:
         fsGroup: 0
 {{- if .node.securityContext }}

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -2,7 +2,7 @@
 kind: {{ .kind }}
 apiVersion: {{ .apiVersion }}
 metadata:
-  annotations: 
+  annotations:
 {{- if .root.Values.global.pegaTier }}{{- if .root.Values.global.pegaTier.annotations }}
 {{ toYaml .root.Values.global.pegaTier.annotations | indent 4 }}
 {{- end }}{{- end }}
@@ -78,7 +78,7 @@ spec:
       nodeSelector:
 {{ toYaml .node.nodeSelector | indent 8 }}
 {{- end }}
-{{- if (ne .root.Values.global.provider "openshift") }}
+{{- if or (ne .root.Values.global.provider "openshift") (.root.Values.global.runWithRestrictedUserPermissions) }}
       securityContext:
         fsGroup: 0
 {{- if .node.securityContext }}

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -78,7 +78,8 @@ spec:
       nodeSelector:
 {{ toYaml .node.nodeSelector | indent 8 }}
 {{- end }}
-{{- if or (ne .root.Values.global.provider "openshift") (coalesce .root.Values.global.runWithRestrictedUserPermissions false) }}
+{{- $useRestrictedRunAsUser := default "false" .root.Values.global.runWithRestrictedUserPermissions }}
+{{- if or (ne .root.Values.global.provider "openshift") (eq (print "%s" $useRestrictedRunAsUser) (print "%s" "true")) }}
       securityContext:
         fsGroup: 0
 {{- if .node.securityContext }}

--- a/charts/pega/templates/pega-environment-config.yaml
+++ b/charts/pega/templates/pega-environment-config.yaml
@@ -75,4 +75,4 @@ data:
   HZ_SERVER_HOSTNAME: {{ template "hazelcastName" . }}-service.{{ .Release.Namespace }}.svc.cluster.local
 {{- end }}
 {{ end }}
-  RUN_AS_RESTRICTED_USER: {{ .Values.global.runWithRestrictedUserPermissions | default "false" }}
+  RUN_AS_RESTRICTED_USER: {{ .Values.global.runWithRestrictedUserPermissions | default "false" | quote }}

--- a/charts/pega/templates/pega-environment-config.yaml
+++ b/charts/pega/templates/pega-environment-config.yaml
@@ -75,3 +75,4 @@ data:
   HZ_SERVER_HOSTNAME: {{ template "hazelcastName" . }}-service.{{ .Release.Namespace }}.svc.cluster.local
 {{- end }}
 {{ end }}
+  RUN_AS_RESTRICTED_USER: {{ .Values.global.runWithRestrictedUserPermissions | default "false" }}

--- a/charts/pega/values-large.yaml
+++ b/charts/pega/values-large.yaml
@@ -54,6 +54,11 @@ global:
     pega:
       image: "pegasystems/pega"
 
+  # If set to "true", Pega pods will be run with a user having restricted permissions.
+  # See the readme for information if running on Openshift as there is additional
+  # required admin configuration required to leverage this feature.
+  runWithRestrictedUserPermissions: "false"
+
   # Upgrade specific properties
   upgrade:
     # Configure only for aks/pks

--- a/charts/pega/values-minimal.yaml
+++ b/charts/pega/values-minimal.yaml
@@ -54,6 +54,11 @@ global:
     pega:
       image: "pegasystems/pega"
 
+  # If set to "true", Pega pods will be run with a user having restricted permissions.
+  # See the readme for information if running on Openshift as there is additional
+  # required admin configuration required to leverage this feature.
+  runWithRestrictedUserPermissions: "false"
+
   # Specify the Pega tiers to deploy
   # For a minimal deployment, use a single tier to reduce resource consumption.
   tier:

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -53,6 +53,11 @@ global:
     pega:
       image: "pegasystems/pega"
 
+  # If set to "true", Pega pods will be run with a user having restricted permissions.
+  # See the readme for information if running on Openshift as there is additional
+  # required admin configuration required to leverage this feature.
+  runWithRestrictedUserPermissions: "false"
+
   # Upgrade specific properties
   upgrade:
     # Configure only for aks/pks

--- a/terratest/src/test/pega/data/pega-tier-config-override_values.yaml
+++ b/terratest/src/test/pega/data/pega-tier-config-override_values.yaml
@@ -53,6 +53,8 @@ global:
     pega:
       image: "pegasystems/pega"
 
+  runWithRestrictedUserPermissions: "false"
+
   # Upgrade specific properties
   upgrade:
     # Configure only for aks/pks

--- a/terratest/src/test/pega/data/values_gke_managedcertificate.yaml
+++ b/terratest/src/test/pega/data/values_gke_managedcertificate.yaml
@@ -53,6 +53,8 @@ global:
     pega:
       image: "pegasystems/pega"
 
+  runWithRestrictedUserPermissions: "false"
+
   # Upgrade specific properties
   upgrade:
     # Configure only for aks/pks

--- a/terratest/src/test/pega/pega-environment-config_test.go
+++ b/terratest/src/test/pega/pega-environment-config_test.go
@@ -62,4 +62,5 @@ func VerifyEnvironmentConfig(t *testing.T, yamlContent string, options *helm.Opt
 	require.Equal(t, envConfigData["CASSANDRA_CLUSTER"], "true")
 	require.Equal(t, envConfigData["CASSANDRA_NODES"], "pega-cassandra")
 	require.Equal(t, envConfigData["CASSANDRA_PORT"], "9042")
+	require.Equal(t, envConfigData["RUN_AS_RESTRICTED_USER"], "false")
 }

--- a/terratest/src/test/pega/pega-tier-deployment-with-hzcs_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment-with-hzcs_test.go
@@ -12,25 +12,28 @@ func TestHazelcast(t *testing.T) {
 
 	var supportedVendors = []string{"k8s","openshift","eks","gke","aks","pks"}
 	var supportedOperations =  []string{"deploy","install-deploy"}
+	var useRestrictedRunAsUser = []string{"false", "true"}
 
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
 	for _, vendor := range supportedVendors {
 		for _, operation := range supportedOperations {
-			var hazelcastOptions = &helm.Options{
-				SetValues: map[string]string{
-					"global.provider":        vendor,
-					"global.actions.execute": operation,
-					"hazelcast.enabled":  "true",
-				},
-			}
-			deploymentYaml := RenderTemplate(t, hazelcastOptions, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
-			yamlSplit := strings.Split(deploymentYaml, "---")
-			assertWeb(t,yamlSplit[1],hazelcastOptions)
-			assertBatch(t,yamlSplit[2],hazelcastOptions)
-			assertStream(t,yamlSplit[3],hazelcastOptions)
-
+		    for _, runAsUser := range useRestrictedRunAsUser {
+                var hazelcastOptions = &helm.Options{
+                    SetValues: map[string]string{
+                        "global.provider":        vendor,
+                        "global.runWithRestrictedUserPermissions": runAsUser,
+                        "global.actions.execute": operation,
+                        "hazelcast.enabled":  "true",
+                    },
+                }
+                deploymentYaml := RenderTemplate(t, hazelcastOptions, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+                yamlSplit := strings.Split(deploymentYaml, "---")
+                assertWeb(t,yamlSplit[1],hazelcastOptions)
+                assertBatch(t,yamlSplit[2],hazelcastOptions)
+                assertStream(t,yamlSplit[3],hazelcastOptions)
+            }
 		}
 	}
 }

--- a/terratest/src/test/pega/pega-tier-deployment-with-hzcs_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment-with-hzcs_test.go
@@ -14,7 +14,6 @@ func TestHazelcast(t *testing.T) {
 	var supportedOperations =  []string{"deploy","install-deploy"}
 	var useRestrictedRunAsUser = []string{"false", "true"}
 	var deploymentNames = []string{"pega","myapp-dev"}
-    var deploymentNames = []string{"pega","myapp-dev"}
 
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)


### PR DESCRIPTION
These changes allow you to run Pega nodes with a user having limited operating system privileges.

To enable this functionality, set `global.runWithRestrictedUserPermissions` to `true`.

There is additional configuration required in order to use this with Openshift -- these steps are detailed in the readme for the Pega chart.