### PR TITLE
US-408948 (Update CloudK Connector settings)

### DIFF
--- a/charts/pega/config/deploy/server.xml
+++ b/charts/pega/config/deploy/server.xml
@@ -75,7 +75,7 @@
                redirectPort="8443" />
 
     <!-- facilitates liveness check via separate port -->
-    <Connector port="8081" protocol="HTTP/1.1"
+    <Connector port="8081" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
                connectionTimeout="20000"
 	       redirectPort="8443" 
 	       maxThreads="1"/>

--- a/charts/pega/config/deploy/server.xml
+++ b/charts/pega/config/deploy/server.xml
@@ -66,9 +66,13 @@
          APR (HTTP/AJP) Connector: /docs/apr.html
          Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
     -->
-    <Connector port="8080" protocol="HTTP/1.1"
+    <Connector port="8080" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+               relaxedQueryChars="[ ]"
+               relaxedPathChars="[ ]"
+               maxHttpHeaderSize="16384"
+               maxSavePostSize="65536"
                connectionTimeout="20000"
-	       redirectPort="8443" />
+               redirectPort="8443" />
 
     <!-- facilitates liveness check via separate port -->
     <Connector port="8081" protocol="HTTP/1.1"

--- a/terratest/src/test/pega/data/expectedInstallDeployServer.xml
+++ b/terratest/src/test/pega/data/expectedInstallDeployServer.xml
@@ -75,7 +75,7 @@
                redirectPort="8443" />
 
     <!-- facilitates liveness check via separate port -->
-    <Connector port="8081" protocol="HTTP/1.1"
+    <Connector port="8081" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
                connectionTimeout="20000"
 	       redirectPort="8443" 
 	       maxThreads="1"/>

--- a/terratest/src/test/pega/data/expectedInstallDeployServer.xml
+++ b/terratest/src/test/pega/data/expectedInstallDeployServer.xml
@@ -66,9 +66,13 @@
          APR (HTTP/AJP) Connector: /docs/apr.html
          Define a non-SSL/TLS HTTP/1.1 Connector on port 8080
     -->
-    <Connector port="8080" protocol="HTTP/1.1"
+    <Connector port="8080" protocol="org.apache.coyote.http11.Http11Nio2Protocol"
+               relaxedQueryChars="[ ]"
+               relaxedPathChars="[ ]"
+               maxHttpHeaderSize="16384"
+               maxSavePostSize="65536"
                connectionTimeout="20000"
-	       redirectPort="8443" />
+               redirectPort="8443" />
 
     <!-- facilitates liveness check via separate port -->
     <Connector port="8081" protocol="HTTP/1.1"


### PR DESCRIPTION
Updated 8080 connector in server.xml to use the following, for parity with cuttyhunk:

* protocol=org.apache.coyote.http11.Http11Nio2Protocol
* relaxedQueryChars="[ ]"
* relaxedPathChars="[ ]"
* maxHttpHeaderSize=16384
* maxSavePostSize=65536