### PR TITLE
Adds note to improve document about Pega Docker image versions in DockerHub.

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -120,7 +120,9 @@ Specify the location for the Pega Docker image.  This image is available on Dock
 
 When using a private registry that requires a username and password, specify them using the `docker.registry.username` and `docker.registry.password` parameters.
 
-When you pull images from DockerHub, Pega recommends that you specify the absolute image version for the image name like `pegasystems/pega:8.x.y` instead of using the `latest` tag. The Pega repository makes the latest images available; however, clients should not pull any image tagged with `latest`. Pega also recommends that clients pull images using the `docker.pega.imagePullPolicy: "IfNotPresent"` for their "Production" deployments, since this setting ensures that a new generic tagged image cannot overwrite the locally cached version.
+When you download Docker images, it is recommended that you specify the absolute image version and the image name instead of using the `latest` tag; for example: `pegasystems/pega:8.4.4` or `platform-services/search-n-reporting-service:1.12.0`. When you download these images with these details from the Pega repository, you pull the latest available image. If you pull images only specifying `latest`, you may not get the image you wanted.
+
+For this reason, it is also recommended that you specify the `docker.pega.imagePullPolicy: "IfNotPresent"` option in production, since it will ensure that a new generic tagged image will not overwrite the locally cached version.
 
 Example:
 

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -120,6 +120,8 @@ Specify the location for the Pega Docker image.  This image is available on Dock
 
 When using a private registry that requires a username and password, specify them using the `docker.registry.username` and `docker.registry.password` parameters.
 
+If using the image from DockerHub, it is recommended to specify the absolute image version along with the image name like `pegasystems/pega:8.4.4` since Kubernetes will pull the image tagged `latest` from DockerHub. This may cause problems especially since image version `8.6` has significant differences in the bootstrap process compared to older versions and is incompatible with a DB configured for version `8.4`. For this reason, it is also recommended to use the `docker.pega.imagePullPolicy: "IfNotPresent"` option in production, since it will ensure that a new generic tagged image will not overwrite the locally cached version.
+
 Example:
 
  ```yaml
@@ -129,7 +131,7 @@ docker:
     username: "YOUR_DOCKER_REGISTRY_USERNAME"
     password: "YOUR_DOCKER_REGISTRY_PASSWORD"
   pega:
-    image: "pegasystems/pega"
+    image: "pegasystems/pega:8.4.4"
     imagePullPolicy: "Always"
 ```
 

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -120,7 +120,7 @@ Specify the location for the Pega Docker image.  This image is available on Dock
 
 When using a private registry that requires a username and password, specify them using the `docker.registry.username` and `docker.registry.password` parameters.
 
-If using the image from DockerHub, it is recommended to specify the absolute image version along with the image name like `pegasystems/pega:8.4.4` since Kubernetes will pull the image tagged `latest` from DockerHub. This may cause problems especially since image version `8.6` has significant differences in the bootstrap process compared to older versions and is incompatible with a DB configured for version `8.4`. For this reason, it is also recommended to use the `docker.pega.imagePullPolicy: "IfNotPresent"` option in production, since it will ensure that a new generic tagged image will not overwrite the locally cached version.
+When you pull images from DockerHub, Pega recommends that you specify the absolute image version for the image name like `pegasystems/pega:8.x.y` instead of using the `latest` tag. The Pega repository makes the latest images available; however, clients should not pull any image tagged with `latest`. Pega also recommends that clients pull images using the `docker.pega.imagePullPolicy: "IfNotPresent"` for their "Production" deployments, since this setting ensures that a new generic tagged image cannot overwrite the locally cached version.
 
 Example:
 


### PR DESCRIPTION
I'm not really sure when this changed but if we use `docker.pega.image: "pegasystems/pega"` in a Pega 8.4.x setup, it no longer works and the pods fail during bootstrap with the following exception:

```
24-May-2021 10:10:06.589 SEVERE [http-nio-8080-exec-5] com.pega.pegarules.internal.bootstrap.PRBootstrap. Unable to retrieve method
        java.lang.NoSuchMethodException: com.pega.pegarules.web.impl.WebStandardImpl.doPostInner(com.pega.pegarules.internal.bootstrap.interfaces.IWebStandard, javax.servlet.http.HttpServletRequest, javax.servlet.http.HttpServletResponse)
```

This is because Kubernetes implicitly pulls the `:latest` tagged image and this seems to have been updated to Pega 8.6 sometime recently and this image is no longer compatible with Pega 8.4.x databases.

I thought it was important to mention this in the documentation since we spent a significant chunk of time debugging failing pods and I notice one another post in the community forums asking for the same resolution as well.