### PR TITLE
Update instructions for manually running terratest tests

### DIFF
--- a/terratest/run-tests-from-cmdline.md
+++ b/terratest/run-tests-from-cmdline.md
@@ -6,7 +6,7 @@ The test can also be run from the command line which allows you to avoid complyi
 - You have a local clone of this repo
 - You have installed an appropriate go version (v1.13 or later)
 - You have installed dep
-- You've disabled go modules by setting the environment variable `GO111MODULE="off"` (v1.16 or later)
+- You have disabled go modules by setting the environment variable `GO111MODULE="off"` (v1.16 or later)
 
 ## Setup
 Add {path to repo}/terratest to the GOPATH environment variable on your local system.

--- a/terratest/run-tests-from-cmdline.md
+++ b/terratest/run-tests-from-cmdline.md
@@ -6,6 +6,7 @@ The test can also be run from the command line which allows you to avoid complyi
 - You have a local clone of this repo
 - You have installed an appropriate go version (v1.13 or later)
 - You have installed dep
+- You've disabled go modules by setting the environment variable `GO111MODULE="off"` (v1.16 or later)
 
 ## Setup
 Add {path to repo}/terratest to the GOPATH environment variable on your local system.

--- a/terratest/run-tests-with-intellij.md
+++ b/terratest/run-tests-with-intellij.md
@@ -3,7 +3,7 @@
     - install Go - version >=1.13 is required
     - install Dep 
     - make sure you have helm version <3.0 installed, as version 3.0. is conflicting with terratest framework for running test through Intellij
-- Install Go plugin for IntelliJ
+- Install Go plugin for IntelliJ (only available for IntelliJ IDEA Ultimate edition)
 - Go to settings (Ctrl + Alt + S)
 - Find option "Languages & Frameworks | Go | GOPATH"
 - In project GOPATH add {path to project}/terratest


### PR DESCRIPTION
As of Go v1.16, the environment variable GO111MODULE is set to on by default. Since the tests rely on GOPATH instead of modules, you have to set GO111MODULE to off.

I also made it explicit that to run the tests via Intellij, you have to have the Ultimate edition.