### PR TITLE
add workflow file for github actions

### DIFF
--- a/.github/workflows/github-actions-build.yml
+++ b/.github/workflows/github-actions-build.yml
@@ -1,0 +1,155 @@
+name: GitHub Actions for pega helm chart
+
+env:
+  HELM_URL: https://get.helm.sh
+  HELM_TGZ: helm-v3.2.4-linux-amd64.tar.gz
+  YAMLLINT_VERSION: 1.15.0
+  GO_VERSION: 1.13.1
+
+
+on: 
+  push:
+    tags:
+      - '*'
+    branches-ignore:
+      - gh-pages
+  pull_request:
+    branches: [ master ]
+
+concurrency:
+  group:  ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  run-build-job:
+    runs-on: ubuntu-18.04
+    steps:
+      - name: Install Helm
+        run: |
+          sudo rm /usr/local/bin/helm
+          wget -q ${{ env.HELM_URL }}/${{ env.HELM_TGZ }}
+          tar xzf ${{ env.HELM_TGZ }}
+          mv linux-amd64/helm /usr/local/bin/helm
+
+      - run: helm version
+      
+      - name: Install yamllint
+        run: |
+          sudo pip install yamllint=="${{ env.YAMLLINT_VERSION }}"
+      
+      - name: Install node
+        uses: actions/setup-node@v2
+        with:
+          node-version: lts/*
+      
+      - name: Install npm dependencies
+        run: |    
+          npm install -g --save remark-cli to-vfile remark-preset-lint-recommended remark-validate-links remark-lint-no-dead-urls remark-message-control remark-preset-lint-markdown-style-guide remark-lint
+      
+      - name: Install GO
+        uses: actions/setup-go@v2
+        with:
+          go-version: ${{ env.GO_VERSION }}
+      - run: export  PATH=$PATH:/usr/local/go/bin
+      
+      
+
+      - name: Check out repository code
+        uses: actions/checkout@v2
+      
+      - name: run yamllint
+        run: |
+          yamllint -c .yamllint.yml -s $(find . -type f -name "Chart.yaml")
+          yamllint -c .yamllint.yml -s $(find . -type f -name "values*.yaml")
+          remark -i .remark_ignore -f -u validate-links .
+      
+      - name: Now load the helm dependencies
+        run: |
+          make dependencies
+          
+      - name: Prepare for GO helm unit tests
+        run: |
+          mkdir $GITHUB_WORKSPACE/terratest/bin
+          export GOPATH=$GITHUB_WORKSPACE/terratest
+          curl https://raw.githubusercontent.com/golang/dep/master/install.sh | sh
+          export PATH=$PATH:$GITHUB_WORKSPACE/terratest/bin
+          cd terratest/src/test
+          dep ensure
+          # grep "FAIL" -A 8 - filter unnecessary logs from the final output but show failing tests
+          #  ; test ${PIPESTATUS[0]} -eq 0 - check if go test was finished success. Without it pipe return exit code from last command.
+          # go test test/pega | grep "FAIL" -A 8 ; test ${PIPESTATUS[0]} -eq 0
+          # go test test/addons | grep "FAIL" -A 8 ; test ${PIPESTATUS[0]} -eq 0
+      
+      - name: run go tests on pega
+        run: |
+          export GOPATH=$GITHUB_WORKSPACE/terratest
+          export PATH=$PATH:$GITHUB_WORKSPACE/terratest/bin
+          cd terratest/src/test
+          go test test/pega | grep "FAIL" -A 8 || true ; test ${PIPESTATUS[0]} -eq 0
+
+      - name: run go tests on addons
+        run: |
+          export GOPATH=$GITHUB_WORKSPACE/terratest
+          export PATH=$PATH:$GITHUB_WORKSPACE/terratest/bin
+          cd terratest/src/test
+          go test test/addons | grep "FAIL" -A 8 || true ; test ${PIPESTATUS[0]} -eq 0
+
+      - name: run go tests on backing services
+        run: |
+          export GOPATH=$GITHUB_WORKSPACE/terratest
+          export PATH=$PATH:$GITHUB_WORKSPACE/terratest/bin
+          cd terratest/src/test
+          go test test/backingservices | grep "FAIL" -A 8 || true ; test ${PIPESTATUS[0]} -eq 0
+
+  run-deploy-job:
+    runs-on: ubuntu-18.04
+    needs: run-build-job
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Install Helm
+        run: |
+          wget -q ${{ env.HELM_URL }}/${{ env.HELM_TGZ }}
+          tar xzf ${{ env.HELM_TGZ }}
+          ls -l
+          mv linux-amd64/helm /usr/local/bin/helm
+          
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Now load the helm dependencies
+        run: |
+          make dependencies
+
+      - name: before deploy step 1
+        run: |
+          cd $GITHUB_WORKSPACE
+          chmod 777 before_deploy.sh
+          ./before_deploy.sh
+
+      - name: before deploy step 2
+        run: |
+          make examples 
+
+
+      - name: deploy on github releases
+        if: |
+          github.ref_type == 'tag' && startsWith(github.ref, 'refs/tags/v')
+        uses: marvinpinto/action-automatic-releases@latest
+        with:
+          prerelease: false
+          files: |
+            pega-kubernetes-example.tar.gz
+            pega-openshift-example.tar.gz
+            pega-azure-aks-example.tar.gz
+            pega-aws-eks-example.tar.gz
+            pega-google-gke-example.tar.gz
+            pega-pivotal-pks-example.tar.gz
+          repo_token: ${{ secrets.NEW_SECRET }}
+
+      - name: deploy on github pages
+        run: |
+          cd $GITHUB_WORKSPACE
+          chmod 777 update_gh_pages.sh
+          ./update_gh_pages.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.NEW_SECRET }}

--- a/before_deploy.sh
+++ b/before_deploy.sh
@@ -2,7 +2,12 @@
 
 # CHART_VERSION is computed from the TAG details of the commit. Every Github release creates tag with the release name.
 # Release name (or) Tag name should be in vX.X.X format. Helm CHART_VERSION would be X.X.X
-export CHART_VERSION=$(expr ${TRAVIS_TAG:1})
+tagVersion = ""
+if [ ${GITHUB_REF_TYPE} == "tag" ]
+then
+    tagVersion = ${GITHUB_REF_NAME}
+fi
+export CHART_VERSION=$(expr ${tagVersion:1})
 export PEGA_FILE_NAME=pega-${CHART_VERSION}.tgz
 export ADDONS_FILE_NAME=addons-${CHART_VERSION}.tgz
 export BACKINGSERVICES_FILE_NAME=backingservices-${CHART_VERSION}.tgz
@@ -12,7 +17,7 @@ export INSTALLER_CONFIGURATIONS_FILE_NAME=installer-config-${CHART_VERSION}.tgz
 curl -o index.yaml https://pegasystems.github.io/pega-helm-charts/index.yaml
 # Clone the versions from gh-pages to a temp directory - xyz
 # The versions will be re-installed in temporary directory - temp_gh_pages
-git clone --single-branch --branch gh-pages https://github.com/${TRAVIS_REPO_SLUG} temp_gh_pages
+git clone --single-branch --branch gh-pages https://github.com/${GITHUB_REPOSITORY} temp_gh_pages
 cp temp_gh_pages/*.tgz .
 rm -rf temp_gh_pages
 ls

--- a/update_gh_pages.sh
+++ b/update_gh_pages.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+set -e
+
+echo "${GITHUB_REF}"
+echo "${GITHUB_REPOSITORY}"
+echo "${GITHUB_TOKEN}"
+echo "${GITHUB_ACTOR}"
+
+repo_uri="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
+remote_name="origin"
+main_branch="master"
+target_branch="gh-pages"
+tmp_build_dir="/tmp/build_dir"
+
+cd "$GITHUB_WORKSPACE"
+
+git config --global user.name "$GITHUB_ACTOR"
+git config --global user.email "${GITHUB_ACTOR}@bots.github.com"
+
+echo "Creating a temporary directory to build"
+mkdir -p "$tmp_build_dir"
+
+
+echo "clone a single branch gh-pages"
+git clone --quiet --branch="$target_branch" --depth=1 "$repo_uri" "$tmp_build_dir" > /dev/null 
+
+cd "$tmp_build_dir"
+
+echo "Copying the files to the temporary build directory"
+rsync -rl --exclude .git --delete "$GITHUB_WORKSPACE/" .
+
+git restore linux-amd64/
+echo $(pwd)
+ls
+git branch
+
+echo "preparing to commit to gh-pages"
+git add -A
+git commit  -qm "Deploy ${GITHUB_REPOSITORY} to ${GITHUB_REPOSITORY}:${target_branch}"
+git show --stat-count=10 HEAD
+
+echo "Pushing to gh-pages"
+git push -q "$remote_name" "$target_branch" > /dev/null 
+
+git status
+
+echo "Pushing to gh-pages complete"


### PR DESCRIPTION
US - Switch helm chart repo from Travis to Github

use cases covered:
1. pr build:
	- run build job alone
2. commits on any branch
	- run the build job
	- run deploy job - pages
3. Tag build
	- run the build job
	- run deploy job - both to Github releases and pages
4. Concurrent builds, cancel the current build, and run the latest one

To see sample runs
https://github.com/smootherbug/pega-helm-charts/actions