### PR TITLE
Update addons chart dependencies for Kubernetes 1.22

### DIFF
--- a/charts/addons/README.md
+++ b/charts/addons/README.md
@@ -19,19 +19,19 @@ Microsoft Azure Kubernetes Service (AKS)  | Application Gateway Ingress Controll
 
 ### Traefik
 
-Deploying Pega Platform with more than one Pod typically requires a load balancer to ensure that traffic is routed equally.  Some IaaS and PaaS providers supply a load balancer and some do not. If a native load balancer is not provided and configured, or the load balancer does not support cookie based session affinity, Traefik may be used instead.  If you do not wish to deploy Traefik, set `traefik.enabled` to `false` in the addons values.yaml configuration. For more configuration options available for Traefik, see the [Traefik Helm chart](https://github.com/helm/charts/blob/master/stable/traefik/values.yaml).
+Deploying Pega Platform with more than one Pod typically requires a load balancer to ensure that traffic is routed equally.  Some IaaS and PaaS providers supply a load balancer and some do not. If a native load balancer is not provided and configured, or the load balancer does not support cookie based session affinity, Traefik may be used instead.  If you do not wish to deploy Traefik, set `traefik.enabled` to `false` in the addons values.yaml configuration. For more configuration options available for Traefik, see the [Traefik Helm chart](https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml).
 
 Example:
 
 ```yaml
 traefik:
   enabled: true
-  serviceType: NodePort
   ssl:
     enabled: false
   rbac:
     enabled: true
   service:
+    type: NodePort
     nodePorts:
       http: 30080
       https: 30443
@@ -114,7 +114,7 @@ Microsoft Azure Kubernetes Service (AKS)  | Azure Monitor
 
 ## Logging with Elasticsearch-Fluentd-Kibana (EFK)
 
-EFK is a standard logging stack that is provided as an example for ease of getting started in environments that do not have aggregated logging configured such as open-source Kubernetes. Other IaaS and PaaS providers typically include a logging system out of the box. You may enable the three components of EFK ([Elasticsearch](https://github.com/helm/charts/tree/master/stable/elasticsearch/values.yaml),[Fluentd](https://github.com/helm/charts/tree/master/stable/fluentd-elasticsearch/values.yaml), and [Kibana](https://github.com/helm/charts/tree/master/stable/kibana/values.yaml)) in the addons values.yaml file to deploy EFK automatically. For more configuration options available for each of the components, see their Helm Charts.
+EFK is a standard logging stack that is provided as an example for ease of getting started in environments that do not have aggregated logging configured such as open-source Kubernetes. Other IaaS and PaaS providers typically include a logging system out of the box. You may enable the three components of EFK ([Elasticsearch](https://github.com/elastic/helm-charts/blob/v7.16.3/elasticsearch/values.yaml),[Fluentd](https://github.com/helm/charts/tree/master/stable/fluentd-elasticsearch/values.yaml), and [Kibana](https://github.com/elastic/helm-charts/blob/v7.16.3/kibana/values.yaml)) in the addons values.yaml file to deploy EFK automatically. For more configuration options available for each of the components, see their Helm Charts.
 
 Example:
 
@@ -158,7 +158,7 @@ All others              | Built-in metrics server
 
 Autoscaling in Kubernetes requires the use of a metrics server, a cluster-wide aggregator of resource usage data.  Most PaaS and IaaS providers supply a metrics server, but if you wish to deploy into open source kubernetes, you will need to supply your own.
 
-See the [metrics-server Helm chart](https://github.com/helm/charts/blob/master/stable/metrics-server/values.yaml) for additional parameters.
+See the [metrics-server Helm chart](https://github.com/kubernetes-sigs/metrics-server/tree/master/charts/metrics-server) for additional parameters.
 
 Example:
 

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -27,6 +27,6 @@ dependencies:
   repository: https://kubernetes-sigs.github.io/metrics-server/
   condition: metrics-server.enabled
 - name: ingress-azure
-  version: "1.5.0-rc1"
+  version: "1.5.0"
   repository: https://appgwingress.blob.core.windows.net/ingress-azure-helm-package/
   condition: ingress-azure.enabled

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -3,8 +3,8 @@
 # * Disable the dependency by setting its condition value (for example, 'traefik.enabled') to false in values.yaml.
 dependencies:
 - name: traefik
-  version: "1.77.1"
-  repository: https://charts.helm.sh/stable
+  version: "10.9.0"
+  repository: https://helm.traefik.io/traefik
   condition: traefik.enabled
 - name: aws-load-balancer-controller
   version: "1.1.0"

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -27,6 +27,6 @@ dependencies:
   repository: https://kubernetes-sigs.github.io/metrics-server/
   condition: metrics-server.enabled
 - name: ingress-azure
-  version: "1.2.0"
+  version: "1.5.0-rc1"
   repository: https://appgwingress.blob.core.windows.net/ingress-azure-helm-package/
   condition: ingress-azure.enabled

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -23,8 +23,8 @@ dependencies:
   repository: https://helm.elastic.co/
   condition: kibana.enabled
 - name: metrics-server
-  version: "2.8.4"
-  repository: https://charts.helm.sh/stable
+  version: "3.7.0"
+  repository: https://kubernetes-sigs.github.io/metrics-server/
   condition: metrics-server.enabled
 - name: ingress-azure
   version: "1.2.0"

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -11,7 +11,7 @@ dependencies:
   repository: https://aws.github.io/eks-charts
   condition: aws-load-balancer-controller.enabled
 - name: elasticsearch
-  version: "7.8.1"
+  version: "7.16.3"
   repository: https://helm.elastic.co/
   condition: elasticsearch.enabled
 - name: fluentd-elasticsearch
@@ -19,7 +19,7 @@ dependencies:
   repository: https://kiwigrid.github.io/
   condition: fluentd-elasticsearch.enabled
 - name: kibana
-  version: "7.8.1"
+  version: "7.16.3"
   repository: https://helm.elastic.co/
   condition: kibana.enabled
 - name: metrics-server

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -7,7 +7,7 @@ dependencies:
   repository: https://helm.traefik.io/traefik
   condition: traefik.enabled
 - name: aws-load-balancer-controller
-  version: "1.1.0"
+  version: "1.3.3"
   repository: https://aws.github.io/eks-charts
   condition: aws-load-balancer-controller.enabled
 - name: elasticsearch

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -21,6 +21,16 @@ traefik:
     websecure:
       port: 443
       nodePort: 30443
+      tls:
+        enabled: false
+        # this is the name of a Traefik TLSOption definition
+        options: ""
+        certResolver: ""
+        domains: []
+        # - main: example.com
+        #   sans:
+        #     - foo.example.com
+        #     - bar.example.com
   resources:
     requests:
       # Enter the CPU Request for Traefik

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -92,7 +92,9 @@ kibana:
     enabled: true
     # Enter the domain name to access kibana via a load balancer.
     hosts:
-      - "YOUR_WEB.KIBANA.EXAMPLE.COM"
+      - host: "YOUR_WEB.KIBANA.EXAMPLE.COM"
+        paths:
+          - path: /
 
 fluentd-elasticsearch:
   enabled: *deploy_efk

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -11,16 +11,17 @@ traefik:
   # See https://github.com/helm/charts/blob/master/stable/traefik/values.yaml
   # To use Traefik as a load balancer in PKS, AKS, GKE, or k8s, set traefik.serviceType: "LoadBalancer".
   serviceType: LoadBalancer
-  # If enabled is set to "true", ssl will be enabled for Traefik
-  ssl:
-    enabled: false
   rbac:
     enabled: true
   service:
-    nodePorts:
-      # NodePorts for Traefik service.
-      http: 30080
-      https: 30443
+    serviceType: NodePorts
+  ports:
+    web: 
+      port: 80
+      nodePort: 30080
+    websecure:
+      port: 443
+      nodePort: 30443
   resources:
     requests:
       # Enter the CPU Request for Traefik

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -15,7 +15,7 @@ traefik:
   service:
     type: LoadBalancer
   ports:
-    web: 
+    web:
       port: 80
       nodePort: 30080
     websecure:

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -16,7 +16,7 @@ traefik:
   service:
     serviceType: NodePorts
   ports:
-    web: 
+    web:
       port: 80
       nodePort: 30080
     websecure:

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -8,15 +8,14 @@
 traefik:
   enabled: false
   # When you set this to true, you can then set additional Traefik parameters to be passed into Traefik's Helm chart.
-  # See https://github.com/helm/charts/blob/master/stable/traefik/values.yaml
+  # See https://github.com/traefik/traefik-helm-chart/blob/master/traefik/values.yaml
   # To use Traefik as a load balancer in PKS, AKS, GKE, or k8s, set traefik.serviceType: "LoadBalancer".
-  serviceType: LoadBalancer
   rbac:
     enabled: true
   service:
-    serviceType: NodePorts
+    serviceType: LoadBalancer
   ports:
-    web:
+    web: 
       port: 80
       nodePort: 30080
     websecure:

--- a/charts/addons/values.yaml
+++ b/charts/addons/values.yaml
@@ -13,7 +13,7 @@ traefik:
   rbac:
     enabled: true
   service:
-    serviceType: LoadBalancer
+    type: LoadBalancer
   ports:
     web: 
       port: 80

--- a/terratest/src/test/addons/metrics-server_test.go
+++ b/terratest/src/test/addons/metrics-server_test.go
@@ -2,7 +2,7 @@ package addons
 
 import (
 	"github.com/stretchr/testify/require"
-	v1 "k8s.io/api/apps/v1"
+	"k8s.io/api/apps/v1"
 	"testing"
 )
 
@@ -78,10 +78,6 @@ var metricServerResources = []SearchResourceOption{
 	{
 		Name: "pega-metrics-server",
 		Kind: "Service",
-	},
-	{
-		Name: "pega-metrics-server-test",
-		Kind: "Pod",
 	},
 	{
 		Name: "pega-metrics-server",

--- a/terratest/src/test/addons/metrics-server_test.go
+++ b/terratest/src/test/addons/metrics-server_test.go
@@ -47,7 +47,7 @@ func Test_shouldContainCommandArgs(t *testing.T) {
 		Kind: "Deployment",
 	}, &deployment)
 
-	require.Contains(t, deployment.Spec.Template.Spec.Containers[0].Command, "--logtostderr")
+	require.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--logtostderr")
 }
 
 var metricServerResources = []SearchResourceOption{

--- a/terratest/src/test/addons/traefik_test.go
+++ b/terratest/src/test/addons/traefik_test.go
@@ -223,7 +223,15 @@ func Test_checkDefaultResourceLimits(t *testing.T) {
 var traefikResources = []SearchResourceOption{
 	{
 		Name: "pega-traefik",
-		Kind: "ConfigMap",
+		Kind: "ServiceAccount",
+	},
+	{
+		Name: "pega-traefik",
+		Kind: "ClusterRole",
+	},
+	{
+		Name: "pega-traefik",
+		Kind: "ClusterRoleBinding",
 	},
 	{
 		Name: "pega-traefik",
@@ -231,14 +239,10 @@ var traefikResources = []SearchResourceOption{
 	},
 	{
 		Name: "pega-traefik",
-		Kind: "Service",
+		Kind: "List",
 	},
 	{
-		Name: "pega-traefik-test",
-		Kind: "Pod",
-	},
-	{
-		Name: "pega-traefik-test",
-		Kind: "ConfigMap",
+		Name: "pega-traefik-dashboard",
+		Kind: "IngressRoute",
 	},
 }

--- a/terratest/src/test/addons/traefik_test.go
+++ b/terratest/src/test/addons/traefik_test.go
@@ -3,6 +3,7 @@ package addons
 import (
 	"testing"
 
+	"github.com/gruntwork-io/terratest/modules/helm"
 	"github.com/stretchr/testify/require"
 	v12 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
@@ -57,23 +58,26 @@ func Test_shouldBeAbleToSetUpServiceTypeAsLoadBalancer(t *testing.T) {
 }
 
 func Test_shouldBeAbleToSetUpServiceTypeAsNodePort(t *testing.T) {
+
 	helmChartParser := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"traefik.enabled":     "true",
-			"traefik.serviceType": "NodePort",
+			"traefik.enabled":      "true",
+			"traefik.service.type": "NodePort",
 		}),
 	)
 
-	var service *v1.Service
-	helmChartParser.Find(SearchResourceOption{
-		Name: "pega-traefik",
-		Kind: "Service",
-	}, &service)
+	var d DeploymentMetadata
+	var list string
+	for _, slice := range helmChartParser.SlicedResource {
+		helm.UnmarshalK8SYaml(helmChartParser.T, slice, &d)
+		if d.Kind == "List" {
+			list = slice
+			break
+		}
+	}
 
-	serviceType := service.Spec.Type
-	require.Equal(t, "NodePort", string(serviceType))
-	require.Equal(t, 30080, int(service.Spec.Ports[0].NodePort))
-	require.Equal(t, 30443, int(service.Spec.Ports[1].NodePort))
+	require.True(t, len(list) != 0)
+	require.Contains(t, list, "NodePort")
 }
 
 func Test_hasRoleWhenRbacEnabled(t *testing.T) {

--- a/terratest/src/test/addons/traefik_test.go
+++ b/terratest/src/test/addons/traefik_test.go
@@ -134,15 +134,18 @@ func Test_hasSecretWhenSSLEnabled(t *testing.T) {
 func Test_hasNoSecretWhenSSLEnabled(t *testing.T) {
 	helmChartParser := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"traefik.enabled":     "true",
-			"traefik.ssl.enabled": "false",
+			"traefik.enabled":                     "true",
+			"traefik.ports.websecure.tls.enabled": "false",
 		}),
 	)
 
-	require.False(t, helmChartParser.Contains(SearchResourceOption{
-		Name: "pega-traefik-default-cert",
-		Kind: "Secret",
-	}))
+	var deployment v12.Deployment
+	helmChartParser.Find(SearchResourceOption{
+		Name: "pega-traefik",
+		Kind: "Deployment",
+	}, &deployment)
+
+	require.NotContains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--entrypoints.websecure.http.tls=true")
 }
 
 func Test_checkResourceRequests(t *testing.T) {

--- a/terratest/src/test/addons/traefik_test.go
+++ b/terratest/src/test/addons/traefik_test.go
@@ -1,10 +1,11 @@
 package addons
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/require"
 	v12 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
-	"testing"
 )
 
 func Test_shouldNotContainTraefikResourcesWhenDisabled(t *testing.T) {
@@ -116,8 +117,8 @@ func Test_noRoleWhenRbacDisabled(t *testing.T) {
 func Test_hasSecretWhenSSLEnabled(t *testing.T) {
 	helmChartParser := NewHelmConfigParser(
 		NewHelmTest(t, helmChartRelativePath, map[string]string{
-			"traefik.enabled":     "true",
-			"traefik.ssl.enabled": "true",
+			"traefik.enabled":                     "true",
+			"traefik.ports.websecure.tls.enabled": "true",
 		}),
 	)
 
@@ -127,13 +128,7 @@ func Test_hasSecretWhenSSLEnabled(t *testing.T) {
 		Kind: "Deployment",
 	}, &deployment)
 
-	require.True(t, helmChartParser.Contains(SearchResourceOption{
-		Name: "pega-traefik-default-cert",
-		Kind: "Secret",
-	}))
-
-	require.Equal(t, "ssl", deployment.Spec.Template.Spec.Volumes[1].Name)
-	require.Equal(t, "pega-traefik-default-cert", deployment.Spec.Template.Spec.Volumes[1].Secret.SecretName)
+	require.Contains(t, deployment.Spec.Template.Spec.Containers[0].Args, "--entrypoints.websecure.http.tls=true")
 }
 
 func Test_hasNoSecretWhenSSLEnabled(t *testing.T) {


### PR DESCRIPTION
ISSUE #376 was recently created because some of our dependencies in the addons chart were using deprecated API versions that were not in Kubernetes 1.22.  This was causing a helm install of the chart to fail.

I'm not certain we want to merge this pr yet but I though it would be a good idea to open it.   I'm hesitant because the [ingress-azure](https://github.com/Azure/application-gateway-kubernetes-ingress) chart only added K8s 1.22 support in their most recent release candidate, 1.5.0-rc1.  [There's an issue open on their project](https://github.com/Azure/application-gateway-kubernetes-ingress/issues/1317) about releasing 1.5.0 but so far it hasn't had any positive feedback.  Apparently the GA release for AKS on K8s 1.22 uses the release candidate as well.