### PR TITLE
Disable autoDeploy feature in default config.

### DIFF
--- a/charts/pega/config/deploy/server.xml.tmpl
+++ b/charts/pega/config/deploy/server.xml.tmpl
@@ -173,7 +173,7 @@
       </Realm>
 
       <Host name="localhost"  appBase="webapps"
-            unpackWARs="true" autoDeploy="true">
+            unpackWARs="true" autoDeploy="false">
 
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->

--- a/terratest/src/test/pega/data/expectedInstallDeployServer.xml.tmpl
+++ b/terratest/src/test/pega/data/expectedInstallDeployServer.xml.tmpl
@@ -173,7 +173,7 @@
       </Realm>
 
       <Host name="localhost"  appBase="webapps"
-            unpackWARs="true" autoDeploy="true">
+            unpackWARs="true" autoDeploy="false">
 
         <!-- SingleSignOn valve, share authentication between web applications
              Documentation at: /docs/config/valve.html -->


### PR DESCRIPTION
Disable autoDeploy feature of tomcat in default config used by the chart.