### PR TITLE
US-465531

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,42 +141,8 @@ Digest: <encryption verification>
 Status: Downloaded pega-docker.downloads.pega.com/platform/pega:<version>
 ```
 
-For details, see the examples listed in the preparation runbook:
+For details about downloading and then pushing Docker images to your repository for your deployment, see [Using Pega-provided Docker images](https://docs.pega.com/client-managed-cloud/87/pega-provided-docker-images).
 
-* [Preparing your local Linux system](docs/prepping-local-system-runbook-linux.md)
-* [Preparing your local Windows 10 system](docs/prepping-local-system-runbook-windows.md)
-
-Pegasystems uses a standard naming practice of hostname/product/image:tag. Pega images are available from the host site, pega-docker.downloads.pega.com. Pega maintains four types of required Docker images for Client-managed Cloud deployments of Pega Platform:
-
- Name                                           | Description                                           | Tags     |
-------------------------------------------------|-------------------------------------------------------|----------|
-`platform/installer`                            | A utility image with which you install all of the Pega-specific rules and database tables in the “Pega” database that you have configured for your deployment. This installation is required before a deployment can take place.| `<version>` |
-`platform/pega`                                 | (Download required) Deploys Pega Platform with its customized version of the Tomcat application server.| `<version>` or `<version>-YYYYMMDD` |
-`platform/search`                               | (Download required) Deploys the required search engine for Pega Platform search and reporting capabilities. This Docker image contains Elasticsearch and includes all required plugins.| `<version>` or `<version>-YYYYMMDD`. |
-`platform-services/search-n-reporting-service`  | An image that deploys the required search engine for the latest generation of search and reporting capabilities in Pega Infinity as a backing service. This Docker image contains Pega Search and Reporting Services. For more information about this service, see [Instructions to configure the Pega backingservices](charts/backingservices/README.md). | `<version>` |
-`platform/clustering-service`                   | An image that deploys the required clustering service(Hazelcast) for the caching capabilities in Pega Infinity as a backing service. This Docker image contains Hazelcast clustering Service. **Note:** This feature is supported only from platform version "8.6" to deploy the infinity in client-server Hazelcast model. Embedded deployment would not be supported in future platform releases.| `<version>` |
-
-For the `platform/installer` image, the :tag represents the version of Pega you want to install, for example the tag :8.5.1 will install Pega Platform version 8.5.1.
-
-For `platform/pega` and `platform/search` images, Pega also offers an image with a version tag appended with a datestamp using the pattern `pegaVersion-YYYYMMDD` to indicate the version and the date that Pega built the image. For example, if you pull the `platform/pega` with a tag, `pega:8.5.1-20201026`, the tag indicates that Pega built this 8.5.1 image on 26 October 2020. Using the version tag without the datestamp will always point to the most recently built image for that version.
-
-The Docker image `platform-services/search-n-reporting-service` is used with the [Search and Reporting Service](charts/backingservices/charts/srs), or SRS subchart under [backing services](charts/backingservices). The SRS subchart deployment provisions the latest generation of search and reporting capabilities in Pega Infinity. This service is an alternate search feature to the previously used `platform/search` image-based Elasticsearch deployment. To configure this service, see [Instructions to configure the Pega backingservices](charts/backingservices/README.md). 
-
-For Pega Platform 8.6 and later, Pega supports a new client-server deployment model using a cluster of nodes running Hazelcast as server,
-to which the Pega nodes connect as client. This new client-server deployment model introduces improved stability for Pega Platform
-deployments that use a large number of nodes, since it introduces independent scalability for both servers and clients in Pega Platform.
-Because of the inherent stability and scalability of this model, **Pega recommends that all clients deploying Pega platform 8.6 and later adopt
-this client-server model using Hazelcast. Embedded deployment would not be supported in future platform releases.**
-To deploy Pega platform and Hazelcast using this client-server deployment model, you must download and push the Clustering Service Docker image,
-`platform/clustering-service` to your Docker repository and use with the Hazelcast subchart under [Pega charts](charts/pega/charts).For the `platform/clustering-service` image, the :tag represents the version of Clustering Service you want to install, for example the tag :1.0.3 will install clustering-service version 1.0.3.
-
-The datestamp ensures that the image you download includes the changes that Pega engineering commits to the repository using pull requests by a certain date. While Pega builds the most current patch version of each minor release one time each day, Pega makes the last five daily-built images available for client downloads.  After Pega releases a new patch version, the prior patch version no longer receives daily builds with a datestamp tag.
-
-After you obtain access to the Pega-provided host repository and pull each image, you can re-tag and push each of the Pega-provided images to your preferred Docker registry to make them available to the deployment. For an overview of tagging and managing Docker images, see the Docker article, [Deploy a registry server](https://docs.docker.com/registry/deploying/).
-
-After you have the images in your Docker repository, you then provide your registry URL, credentials, and reference each image appropriately in the Pega Helm chart. You can find example usage details for referencing the three images in a repository in the appropriate runbook for your type of deployment.
-
-These images do not expire, and you can keep them in your repository for as long as you require.
 
 # Contributing
 


### PR DESCRIPTION
Removed linux/windows, now located at https://docs.pega.com/client-managed-cloud/87/pega-provided-docker-images