### PR TITLE
Make traefik config fully optional

### DIFF
--- a/before_deploy.sh
+++ b/before_deploy.sh
@@ -25,7 +25,7 @@ ls
 helm package --version ${CHART_VERSION} ./charts/pega/
 helm package --version ${CHART_VERSION} ./charts/addons/
 helm package --version ${CHART_VERSION} ./charts/backingservices/
-tar -czvf ${DEPLOY_CONFIGURATIONS_FILE_NAME} --directory=./charts/pega/config deploy/context.xml.tmpl deploy/server.xml deploy/prconfig.xml deploy/prlog4j2.xml
+tar -czvf ${DEPLOY_CONFIGURATIONS_FILE_NAME} --directory=./charts/pega/config deploy/context.xml.tmpl deploy/server.xml.tmpl deploy/prconfig.xml deploy/prlog4j2.xml
 mkdir -p ./charts/pega/charts/installer/config/installer && cp ./charts/pega/charts/installer/config/migrateSystem.properties.tmpl ./charts/pega/charts/installer/config/installer && cp ./charts/pega/charts/installer/config/prbootstrap.properties.tmpl ./charts/pega/charts/installer/config/installer && cp ./charts/pega/charts/installer/config/prconfig.xml.tmpl ./charts/pega/charts/installer/config/installer && cp ./charts/pega/charts/installer/config/prlog4j2.xml ./charts/pega/charts/installer/config/installer && cp ./charts/pega/charts/installer/config/prpcUtils.properties.tmpl ./charts/pega/charts/installer/config/installer && cp ./charts/pega/charts/installer/config/setupDatabase.properties.tmpl ./charts/pega/charts/installer/config/installer && tar -czvf ${INSTALLER_CONFIGURATIONS_FILE_NAME} --directory=./charts/pega/charts/installer/config installer/migrateSystem.properties.tmpl installer/prbootstrap.properties.tmpl installer/prconfig.xml.tmpl installer/prlog4j2.xml installer/prpcUtils.properties.tmpl installer/setupDatabase.properties.tmpl
 # and merge it
 helm repo index --merge index.yaml --url https://pegasystems.github.io/pega-helm-charts/ .

--- a/charts/pega/templates/_pega-traefik-config.tpl
+++ b/charts/pega/templates/_pega-traefik-config.tpl
@@ -1,7 +1,8 @@
 {{- define "pegaTraefikConfigTemplate" }}
 # Secret used for tls certificates to configure https to tomcat
 {{- if ((.node.service).tls).enabled }}
-{{- if .node.service.tls.traefik.enabled }}
+{{- if (.node.service.tls.traefik) }}
+{{- if (.node.service.tls.traefik.enabled) }}
 kind: ServersTransport
 apiVersion: traefik.containo.us/v1alpha1
 metadata:
@@ -24,4 +25,5 @@ spec:
 {{- end }}
 {{- end }}
 {{- end }}
-{{- end}}
+{{- end }}
+{{- end }}


### PR DESCRIPTION
Address #442 and check that `.node.service.tls.traefik` exists before checking `.node.service.tls.traefik.enabled` so that users do not have to modify their values to include the latter.