### PR TITLE
Use pegasystems/k8s-wait-for image for job ordering 

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -184,7 +184,7 @@ utilityImages:
     image: "busybox:1.31.0"
     imagePullPolicy: "IfNotPresent"
   k8s_wait_for:
-    image: "dcasavant/k8s-wait-for"
+    image: "pegasystems/k8s-wait-for"
     imagePullPolicy: "IfNotPresent"
 ```
 

--- a/charts/pega/charts/installer/templates/_helpers.tpl
+++ b/charts/pega/charts/installer/templates/_helpers.tpl
@@ -75,9 +75,9 @@
   args: [ 'job', '{{ template "pegaDBInstall" }}']
   env:  
     - name: WAIT_TIME
-      value: "{{ template "k8sWaitForWaitTime" }}"
+      value: "{{ template "k8sWaitForWaitTime" $ }}"
     - name: MAX_RETRIES
-      value: "{{ template "k8sWaitForMaxRetries"}}"
+      value: "{{ template "k8sWaitForMaxRetries" $ }}"
 {{- end }}
 
 {{- define "waitForPegaDBZDTUpgrade" -}}
@@ -87,9 +87,9 @@
   args: [ 'job', '{{ template "pegaDBZDTUpgrade" }}']
   env:  
     - name: WAIT_TIME
-      value: "{{ template "k8sWaitForWaitTime" }}"
+      value: "{{ template "k8sWaitForWaitTime" $ }}"
     - name: MAX_RETRIES
-      value: "{{ template "k8sWaitForMaxRetries"}}"
+      value: "{{ template "k8sWaitForMaxRetries" $ }}"
 {{- include "initContainerEnvs" $ }}
 {{- end }}
 
@@ -100,9 +100,9 @@
   args: [ 'job', '{{ template "pegaPreDBUpgrade" }}']
   env:  
     - name: WAIT_TIME
-      value: "{{ template "k8sWaitForWaitTime" }}"
+      value: "{{ template "k8sWaitForWaitTime" $ }}"
     - name: MAX_RETRIES
-      value: "{{ template "k8sWaitForMaxRetries"}}"
+      value: "{{ template "k8sWaitForMaxRetries" $ }}"
 {{- end }}
 
 {{- define "waitForRollingUpdates" -}}
@@ -145,9 +145,9 @@
   - name: KUBERNETES_SERVICE_PORT
     value: {{ $apiserver.httpsServicePort | quote }}
   - name: WAIT_TIME
-    value: "{{ template "k8sWaitForWaitTime" }}"
+    value: "{{ template "k8sWaitForWaitTime" $ }}"
   - name: MAX_RETRIES
-    value: "{{ template "k8sWaitForMaxRetries"}}"
+    value: "{{ template "k8sWaitForMaxRetries" $ }}"
 {{- end }}
 {{- end }}
 

--- a/charts/pega/charts/installer/templates/_helpers.tpl
+++ b/charts/pega/charts/installer/templates/_helpers.tpl
@@ -32,6 +32,16 @@
   {{- end -}}
 {{- end -}}
 
+{{- define "k8sWaitForMaxRetries" -}}
+  {{- if (.Values.global.utilityImages.k8s_wait_for) -}}
+    {{- if (.Values.global.utilityImages.k8s_wait_for.maxRetries) -}}
+      {{ .Values.global.utilityImages.k8s_wait_for.maxRetries }}
+    {{- else -}}
+      1
+    {{- end -}}
+  {{- end -}}
+{{- end -}}
+
 {{- define "installerDeploymentName" }}{{ $deploymentNamePrefix := "pega" }}{{ if (.Values.global.deployment) }}{{ if (.Values.global.deployment.name) }}{{ $deploymentNamePrefix = .Values.global.deployment.name }}{{ end }}{{ end }}{{ $deploymentNamePrefix }}{{- end }}
 
 {{- define "performInstall" }}
@@ -66,6 +76,8 @@
   env:  
     - name: WAIT_TIME
       value: "{{ template "k8sWaitForWaitTime" }}"
+    - name: MAX_RETRIES
+      value: "{{ template "k8sWaitForMaxRetries"}}"
 {{- end }}
 
 {{- define "waitForPegaDBZDTUpgrade" -}}
@@ -76,6 +88,8 @@
   env:  
     - name: WAIT_TIME
       value: "{{ template "k8sWaitForWaitTime" }}"
+    - name: MAX_RETRIES
+      value: "{{ template "k8sWaitForMaxRetries"}}"
 {{- include "initContainerEnvs" $ }}
 {{- end }}
 
@@ -87,6 +101,8 @@
   env:  
     - name: WAIT_TIME
       value: "{{ template "k8sWaitForWaitTime" }}"
+    - name: MAX_RETRIES
+      value: "{{ template "k8sWaitForMaxRetries"}}"
 {{- end }}
 
 {{- define "waitForRollingUpdates" -}}
@@ -128,6 +144,10 @@
     value: {{ $apiserver.httpsServicePort | quote }}
   - name: KUBERNETES_SERVICE_PORT
     value: {{ $apiserver.httpsServicePort | quote }}
+  - name: WAIT_TIME
+    value: "{{ template "k8sWaitForWaitTime" }}"
+  - name: MAX_RETRIES
+    value: "{{ template "k8sWaitForMaxRetries"}}"
 {{- end }}
 {{- end }}
 

--- a/charts/pega/values-large.yaml
+++ b/charts/pega/values-large.yaml
@@ -99,9 +99,10 @@ global:
       image: busybox:1.31.0
       imagePullPolicy: IfNotPresent
     k8s_wait_for:
-      image: dcasavant/k8s-wait-for
+      image: pegasystems/k8s-wait-for
       imagePullPolicy: "IfNotPresent"
       # waitTimeSeconds: 2
+      # maxRetries: 1
 
   # Upgrade specific properties
   upgrade:

--- a/charts/pega/values-minimal.yaml
+++ b/charts/pega/values-minimal.yaml
@@ -95,8 +95,10 @@ global:
       image: busybox:1.31.0
       imagePullPolicy: IfNotPresent
     k8s_wait_for:
-      image: dcasavant/k8s-wait-for
+      image: pegasystems/k8s-wait-for
       imagePullPolicy: "IfNotPresent"
+      # waitTimeSeconds: 2
+      # maxRetries: 1
 
   # Specify the Pega tiers to deploy
   # For a minimal deployment, use a single tier to reduce resource consumption.

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -99,9 +99,10 @@ global:
       image: busybox:1.31.0
       imagePullPolicy: IfNotPresent
     k8s_wait_for:
-      image: dcasavant/k8s-wait-for
+      image: pegasystems/k8s-wait-for
       imagePullPolicy: "IfNotPresent"
       # waitTimeSeconds: 2
+      # maxRetries: 1
 
   # Upgrade specific properties
   upgrade:

--- a/terratest/src/test/pega/data/values_http_disabled.yaml
+++ b/terratest/src/test/pega/data/values_http_disabled.yaml
@@ -96,9 +96,10 @@ global:
       image: busybox:1.31.0
       imagePullPolicy: IfNotPresent
     k8s_wait_for:
-      image: dcasavant/k8s-wait-for
+      image: pegasystems/k8s-wait-for
       imagePullPolicy: "IfNotPresent"
       # waitTimeSeconds: 2
+      # maxRetries: 1
 
   # Upgrade specific properties
   upgrade:

--- a/terratest/src/test/pega/data/values_with_overidden_liveness_probe_config.yaml
+++ b/terratest/src/test/pega/data/values_with_overidden_liveness_probe_config.yaml
@@ -94,9 +94,10 @@ global:
       image: busybox:1.31.0
       imagePullPolicy: IfNotPresent
     k8s_wait_for:
-      image: dcasavant/k8s-wait-for
+      image: pegasystems/k8s-wait-for
       imagePullPolicy: "IfNotPresent"
       # waitTimeSeconds: 2
+      # maxRetries: 1
 
   # Upgrade specific properties
   upgrade:

--- a/terratest/src/test/pega/utilities.go
+++ b/terratest/src/test/pega/utilities.go
@@ -55,7 +55,7 @@ func VerifyInitContainerData(t *testing.T, containers []k8score.Container, optio
 		container := containers[i]
 		name := container.Name
 		if name == "wait-for-pegainstall" {
-			require.Equal(t, "dcasavant/k8s-wait-for", container.Image)
+			require.Equal(t, "pegasystems/k8s-wait-for", container.Image)
 			require.Equal(t, []string{"job", "pega-db-install"}, container.Args)
 		} else if name == "wait-for-pegasearch" {
 			require.Equal(t, "busybox:1.31.0", container.Image)
@@ -65,14 +65,14 @@ func VerifyInitContainerData(t *testing.T, containers []k8score.Container, optio
 			//The cassandra svc name below is derived from helm release name and not .Values.global.deploymentName like search svc
 			require.Equal(t, []string{"sh", "-c", "until cqlsh -u \"dnode_ext\" -p \"dnode_ext\" -e \"describe cluster\" pega-cassandra 9042 ; do echo Waiting for cassandra to become live...; sleep 10; done;"}, container.Command)
 		} else if name == "wait-for-pegaupgrade" {
-			require.Equal(t, "dcasavant/k8s-wait-for", container.Image)
+			require.Equal(t, "pegasystems/k8s-wait-for", container.Image)
 			require.Equal(t, []string{"job", "pega-zdt-upgrade"}, container.Args)
 			aksSpecificUpgraderDeployEnvs(t, options, container)
 		} else if name == "wait-for-pre-dbupgrade" {
-			require.Equal(t, "dcasavant/k8s-wait-for", container.Image)
+			require.Equal(t, "pegasystems/k8s-wait-for", container.Image)
 			require.Equal(t, []string{"job", "pega-pre-upgrade"}, container.Args)
 		} else if name == "wait-for-rolling-updates" {
-			require.Equal(t, "dcasavant/k8s-wait-for", container.Image)
+			require.Equal(t, "pegasystems/k8s-wait-for", container.Image)
 			require.Equal(t, []string{"sh", "-c", " kubectl rollout status deployment/" + depName + "-web --namespace default && kubectl rollout status deployment/" + depName + "-batch --namespace default && kubectl rollout status statefulset/" + depName + "-stream --namespace default"}, container.Command)
 		} else {
 			fmt.Println("invalid init containers found.. please check the list", name)


### PR DESCRIPTION
This PR switches from dcasavant/k8s-wait-for to the pegasystems/k8s-wait-for docker image.

The new image includes additional support for retrying queries to the API server which we have observed on occasion in a subset of our supported cloud providers.

This PR also fixes the rendering of k8s-wait-for initcontainers such that they correctly honor the global.utilityImages.k8s_wait_for.waitTimeSeconds property.