### PR TITLE
ISSUE-548: Fixed SRS Deployment for Ext ES

### DIFF
--- a/charts/backingservices/charts/srs/templates/srsservice_deployment.yaml
+++ b/charts/backingservices/charts/srs/templates/srsservice_deployment.yaml
@@ -26,9 +26,11 @@ spec:
             - name: srs-port
               containerPort: 8080
               protocol: TCP
+          {{- if .Values.srsStorage.tls.enabled }}
           volumeMounts:
             - name: srs-certificates
               mountPath: /usr/share/
+          {{ end }}
           readinessProbe:
             httpGet:
               path: /health
@@ -75,8 +77,6 @@ spec:
                   key: password
             - name: PATH_TO_TRUSTSTORE
               value: "/usr/share/{{ .Values.srsStorage.certificateName | default "elastic-certificates.p12"}}"
-            - name: ELASTICSEARCH_AUTH_PROVIDER
-              value: tls
             {{- end}}
             - name: APPLICATION_HOST
               value: "0.0.0.0"
@@ -90,10 +90,13 @@ spec:
               value: ""
           resources:
             {{- toYaml .Values.srsRuntime.resources | nindent 12 }}
+      {{- if .Values.srsStorage.tls.enabled }}
       volumes:
       - name: srs-certificates
         secret:
           secretName: srs-certificates
+      {{ end }}
+      {{- if .Values.srsStorage.provisionInternalESCluster }}
       initContainers:
       - name: wait-for-internal-es-cluster
         image: {{ .Values.busybox.image }}
@@ -128,4 +131,5 @@ spec:
               secretKeyRef:
                 name: srs-elastic-credentials
                 key: password
+      {{ end }}
   {{ end }}

--- a/terratest/src/test/backingservices/srs-deployment_test.go
+++ b/terratest/src/test/backingservices/srs-deployment_test.go
@@ -206,9 +206,6 @@ func VerifyDeployment(t *testing.T, pod *k8score.PodSpec, expectedSpec srsDeploy
 	require.Equal(t, "PATH_TO_TRUSTSTORE", pod.Containers[0].Env[envIndex].Name)
 	require.Equal(t, "/usr/share/elastic-certificates.p12", pod.Containers[0].Env[envIndex].Value)
 	envIndex++
-	require.Equal(t, "ELASTICSEARCH_AUTH_PROVIDER", pod.Containers[0].Env[envIndex].Name)
-	require.Equal(t, "tls", pod.Containers[0].Env[envIndex].Value)
-	envIndex++
 	}
 	require.Equal(t, "APPLICATION_HOST", pod.Containers[0].Env[envIndex].Name)
     require.Equal(t, "0.0.0.0", pod.Containers[0].Env[envIndex].Value)


### PR DESCRIPTION
**Fixes:**
- Fixed SRS Deployment issue incase of externally managed Elasticsearch server when deployed with no basic authentication. (Issue #548)
- Removed Duplicate ENV Variable `ELASTICSEARCH_AUTH_PROVIDER` while deploying SRS.
