### PR TITLE
US-512993 : Adding the capability to configure servicetype.

### DIFF
--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -43,7 +43,7 @@ spec:
   {{- else -}}
   {{ indent 1 "LoadBalancer" }}
   {{- end }}
-{{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
+{{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) -}}
   loadBalancerSourceRanges:
   - "{{ .node.service.loadBalancerSourceRanges }}"
 {{- end }}

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -43,7 +43,7 @@ spec:
   {{- else -}}
   {{ indent 1 "LoadBalancer" }}
   {{- end }}
-  {{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
+  {{- if and (.node.service.serviceType) (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
   loadBalancerSourceRanges:
   {{- range .node.service.loadBalancerSourceRanges }}
     - "{{ . }}"

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -43,7 +43,7 @@ spec:
   {{- else -}}
   {{ indent 1 "LoadBalancer" }}
   {{- end }}
-{{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) -}}
+{{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
   loadBalancerSourceRanges:
   - "{{ .node.service.loadBalancerSourceRanges }}"
 {{- end }}

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -43,9 +43,9 @@ spec:
   {{- else -}}
   {{ indent 1 "LoadBalancer" }}
   {{- end }}
-{{- if and (.node.service.loadBalancerSourceRanges) (eq .node.service.serviceType "LoadBalancer") }}
+{{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
   loadBalancerSourceRanges:
-  - "{{ .node.service.loadBalancerSourceRanges }}"
+  - {{ .node.service.loadBalancerSourceRanges }}
 {{- end }}
   # Specification of on which port the service is enabled
   ports:

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -43,7 +43,7 @@ spec:
   {{- else -}}
   {{ indent 1 "LoadBalancer" }}
   {{- end }}
-{{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
+{{- if and (.node.service.loadBalancerSourceRanges) (eq .node.service.serviceType "LoadBalancer") }}
   loadBalancerSourceRanges:
   - "{{ .node.service.loadBalancerSourceRanges }}"
 {{- end }}

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -43,7 +43,7 @@ spec:
   {{- else -}}
   {{ indent 1 "LoadBalancer" }}
   {{- end }}
-  {{- if and ( and (.node.service.serviceType) (eq .node.service.serviceType "LoadBalancer")) (.node.service.loadBalancerSourceRanges) }}
+  {{- if and ( and (.node.service.serviceType) (eq (toString .node.service.serviceType) "LoadBalancer")) (.node.service.loadBalancerSourceRanges) }}
   loadBalancerSourceRanges:
   {{- range .node.service.loadBalancerSourceRanges }}
     - "{{ . }}"

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -36,11 +36,17 @@ metadata:
 {{- end }}
 spec:
   type:
-  {{- if or (eq .root.Values.global.provider "gke") (eq .root.Values.global.provider "eks") -}}
+  {{- if (.node.service.serviceType) -}}
+  {{ indent 1 (.node.service.serviceType) }}
+  {{- else if or (eq .root.Values.global.provider "gke") (eq .root.Values.global.provider "eks") -}}
   {{ indent 1 "NodePort" }}
   {{- else -}}
-  {{ indent 1 (.node.service.serviceType | default "LoadBalancer") }}
+  {{ indent 1 "LoadBalancer" }}
   {{- end }}
+{{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
+  loadBalancerSourceRanges:
+  - "{{ .node.service.loadBalancerSourceRanges }}"
+{{- end }}
   # Specification of on which port the service is enabled
   ports:
 {{- if or (not (hasKey .node.service "httpEnabled")) (.node.service.httpEnabled) }}

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -45,7 +45,9 @@ spec:
   {{- end }}
   {{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
   loadBalancerSourceRanges:
-  - {{ .node.service.loadBalancerSourceRanges }}
+  {{- range .node.service.loadBalancerSourceRanges }}
+    - "{{ . }}"
+  {{- end }}
   {{- end }}
   # Specification of on which port the service is enabled
   ports:

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -43,7 +43,7 @@ spec:
   {{- else -}}
   {{ indent 1 "LoadBalancer" }}
   {{- end }}
-  {{- if and (.node.service.serviceType) (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
+  {{- if and ( and (.node.service.serviceType) (eq .node.service.serviceType "LoadBalancer")) (.node.service.loadBalancerSourceRanges) }}
   loadBalancerSourceRanges:
   {{- range .node.service.loadBalancerSourceRanges }}
     - "{{ . }}"

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -43,10 +43,10 @@ spec:
   {{- else -}}
   {{ indent 1 "LoadBalancer" }}
   {{- end }}
-{{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
+  {{- if and (eq .node.service.serviceType "LoadBalancer") (.node.service.loadBalancerSourceRanges) }}
   loadBalancerSourceRanges:
   - {{ .node.service.loadBalancerSourceRanges }}
-{{- end }}
+  {{- end }}
   # Specification of on which port the service is enabled
   ports:
 {{- if or (not (hasKey .node.service "httpEnabled")) (.node.service.httpEnabled) }}

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -174,7 +174,6 @@ global:
             serverName: ""
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
-        
 
       ingress:
         # For help configuring the ingress block including TLS, see the Helm chart documentation

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -168,7 +168,7 @@ global:
         # Specify the CIDR ranges to restrict the service access to the given CIDR range.
         # Each new CIDR block should be added in a separate line.
         # Should be used only when serviceType is set to LoadBalancer.
-        # e.g 
+        # e.g
         # loadBalancerSourceRanges:
         #     - "123.123.123.0/24"
         #     - "128.128.128.64/32"

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -138,6 +138,18 @@ global:
         httpEnabled: true
         port: 80
         targetPort: 8080
+        # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes.
+        # This is an optional value and should be used based on the use case.
+        # This should be set only in case of eks, gke and other cloud providers. This option should not be used for k8s and minikube.
+        # For example if you want to deploy a service of type LoadBalancer, specify serviceType: "LoadBalancer"
+        # serviceType: ""
+        # Specify the CIDR ranges to restrict the service access to the given CIDR range.
+        # Each new CIDR block should be added in a separate line.
+        # Should be used only when serviceType is set to LoadBalancer.
+        # Uncomment the following lines and replaces the CIDR blocks with your configuration requirements.
+        # loadBalancerSourceRanges:
+        #     - "123.123.123.0/24"
+        #     - "128.128.128.64/32"
         # To configure TLS between the ingress/load balancer and the backend, set the following:
         tls:
           enabled: false
@@ -162,18 +174,7 @@ global:
             serverName: ""
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
-        # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes.
-        # This is an optional value and should be used based on the use case.
-        # This should be set only in case of eks, gke and other cloud providers. This option should not be used for k8s and minikube.
-        # For example if you want to deploy a service of type LoadBalancer, specify serviceType: "LoadBalancer"
-        # serviceType: ""
-        # Specify the CIDR ranges to restrict the service access to the given CIDR range.
-        # Each new CIDR block should be added in a separate line.
-        # Should be used only when serviceType is set to LoadBalancer.
-        # Uncomment the following lines and replaces the CIDR blocks with your configuration requirements.
-        # loadBalancerSourceRanges:
-        #     - "123.123.123.0/24"
-        #     - "128.128.128.64/32"
+        
 
       ingress:
         # For help configuring the ingress block including TLS, see the Helm chart documentation

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -162,12 +162,16 @@ global:
             serverName: ""
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
-        serviceType: "LoadBalancer"
-        # Specify the CIDR range inside the qoutations to restrict the service access to the given CIDR range
-        # e.g "123.123.123.0/24"
-        loadBalancerSourceRanges:
-          - "103.38.88.0/24"
-          - "49.43.219.90/32"
+        # Use this parameter to deploy service of a specifictype. This is an optional value and should be used based on the usecase.
+        # serviceType: ""
+        # Should be used only when serviceType is set to LoadBalancer.
+        # Specify the CIDR ranges to restrict the service access to the given CIDR range.
+        # Each new CIDR block should be added in a separate line.
+        # e.g 
+        # loadBalancerSourceRanges:
+        # - "123.123.123.0/24"
+        # - "128.128.128.64/32"
+        # loadBalancerSourceRanges:
 
       ingress:
         # For help configuring the ingress block including TLS, see the Helm chart documentation

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -162,6 +162,10 @@ global:
             serverName: ""
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
+        serviceType: ""
+        # Specify the CIDR range inside the qoutations to restrict the service access to the given CIDR range
+        # e.g "123.123.123.0/24"
+        loadBalancerSourceRanges: ""
 
       ingress:
         # For help configuring the ingress block including TLS, see the Helm chart documentation

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -162,10 +162,12 @@ global:
             serverName: ""
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
-        serviceType: ""
+        serviceType: "LoadBalancer"
         # Specify the CIDR range inside the qoutations to restrict the service access to the given CIDR range
         # e.g "123.123.123.0/24"
-        loadBalancerSourceRanges: ""
+        loadBalancerSourceRanges:
+        - "103.38.88.0/24"
+        - "49.43.219.90/32"
 
       ingress:
         # For help configuring the ingress block including TLS, see the Helm chart documentation

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -164,7 +164,7 @@ global:
             insecureSkipVerify: false
         # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes.
         # This is an optional value and should be used based on the use case.
-        # This should be set only in case of eks, gke and other cloud providers. This option is should not be used for k8s and minikube.
+        # This should be set only in case of eks, gke and other cloud providers. This option should not be used for k8s and minikube.
         # For example if you want to deploy a service of type LoadBalancer, specify serviceType: "LoadBalancer"
         # serviceType: ""
         # Specify the CIDR ranges to restrict the service access to the given CIDR range.

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -138,6 +138,18 @@ global:
         httpEnabled: true
         port: 80
         targetPort: 8080
+        # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes.
+        # This is an optional value and should be used based on the use case.
+        # This should be set only in case of eks, gke and other cloud providers. This option is should not be used for k8s and minikube.
+        # For example if you want to deploy a service of type LoadBalancer, specify serviceType: "LoadBalancer"
+        # serviceType: ""
+        # Specify the CIDR ranges to restrict the service access to the given CIDR range.
+        # Each new CIDR block should be added in a separate line.
+        # Should be used only when serviceType is set to LoadBalancer.
+        # Uncomment the following lines and replaces the CIDR blocks with your configuration requirements.
+        # loadBalancerSourceRanges:
+        #     - "123.123.123.0/24"
+        #     - "128.128.128.64/32"
         # To configure TLS between the ingress/load balancer and the backend, set the following:
         tls:
           enabled: false
@@ -162,18 +174,7 @@ global:
             serverName: ""
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
-        # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes.
-        # This is an optional value and should be used based on the use case.
-        # This should be set only in case of eks, gke and other cloud providers. This option is should not be used for k8s and minikube.
-        # For example if you want to deploy a service of type LoadBalancer, specify serviceType: "LoadBalancer"
-        # serviceType: ""
-        # Specify the CIDR ranges to restrict the service access to the given CIDR range.
-        # Each new CIDR block should be added in a separate line.
-        # Should be used only when serviceType is set to LoadBalancer.
-        # Uncomment the following lines and replaces the CIDR blocks with your configuration requirements.
-        # loadBalancerSourceRanges:
-        #     - "123.123.123.0/24"
-        #     - "128.128.128.64/32"
+        
 
       ingress:
         # For help configuring the ingress block including TLS, see the Helm chart documentation

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -162,7 +162,7 @@ global:
             serverName: ""
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
-        # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes. 
+        # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes.
         # This is an optional value and should be used based on the use case.
         # This should be set only in case of eks, gke and other cloud providers. This option is should not be used for k8s and minikube.
         # For example if you want to deploy a service of type LoadBalancer, specify serviceType: "LoadBalancer"

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -508,3 +508,4 @@ stream:
   # STREAM_TRUSTSTORE_PASSWORD, STREAM_KEYSTORE_PASSWORD and STREAM_JAAS_CONFIG.
   # Enter the external secret name below.
   external_secret_name: ""
+  

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -162,13 +162,15 @@ global:
             serverName: ""
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
-        # Use this parameter to deploy service of a specifictype. This is an optional value and should be used based on the usecase.
-        # This should be set only in case of eks, gke and other cloud providers. This option is unavailable for k8s and minikube.
+        # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes. 
+        # This is an optional value and should be used based on the use case.
+        # This should be set only in case of eks, gke and other cloud providers. This option is should not be used for k8s and minikube.
+        # For example if you want to deploy a service of type LoadBalancer, specify serviceType: "LoadBalancer"
         # serviceType: ""
         # Specify the CIDR ranges to restrict the service access to the given CIDR range.
         # Each new CIDR block should be added in a separate line.
         # Should be used only when serviceType is set to LoadBalancer.
-        # e.g
+        # Uncomment the following lines and replaces the CIDR blocks with your configuration requirements.
         # loadBalancerSourceRanges:
         #     - "123.123.123.0/24"
         #     - "128.128.128.64/32"

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -146,7 +146,7 @@ global:
         # Specify the CIDR ranges to restrict the service access to the given CIDR range.
         # Each new CIDR block should be added in a separate line.
         # Should be used only when serviceType is set to LoadBalancer.
-        # Uncomment the following lines and replaces the CIDR blocks with your configuration requirements.
+        # Uncomment the following lines and replace the CIDR blocks with your configuration requirements.
         # loadBalancerSourceRanges:
         #     - "123.123.123.0/24"
         #     - "128.128.128.64/32"

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -508,4 +508,3 @@ stream:
   # STREAM_TRUSTSTORE_PASSWORD, STREAM_KEYSTORE_PASSWORD and STREAM_JAAS_CONFIG.
   # Enter the external secret name below.
   external_secret_name: ""
-  

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -141,7 +141,7 @@ global:
         # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes.
         # This is an optional value and should be used based on the use case.
         # This should be set only in case of eks, gke and other cloud providers. This option should not be used for k8s and minikube.
-        # For example if you want to deploy a service of type LoadBalancer, specify serviceType: "LoadBalancer"
+        # For example if you want to deploy a service of type LoadBalancer, uncomment the following line and specify serviceType: "LoadBalancer"
         # serviceType: ""
         # Specify the CIDR ranges to restrict the service access to the given CIDR range.
         # Each new CIDR block should be added in a separate line.

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -163,14 +163,15 @@ global:
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
         # Use this parameter to deploy service of a specifictype. This is an optional value and should be used based on the usecase.
+        # This should be set only in case of eks, gke and other cloud providers. This option is unavailable for k8s and minikube.
         # serviceType: ""
-        # Should be used only when serviceType is set to LoadBalancer.
         # Specify the CIDR ranges to restrict the service access to the given CIDR range.
         # Each new CIDR block should be added in a separate line.
+        # Should be used only when serviceType is set to LoadBalancer.
         # e.g 
         # loadBalancerSourceRanges:
-        # - "123.123.123.0/24"
-        # - "128.128.128.64/32"
+        #     - "123.123.123.0/24"
+        #     - "128.128.128.64/32"
         # loadBalancerSourceRanges:
 
       ingress:

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -138,18 +138,6 @@ global:
         httpEnabled: true
         port: 80
         targetPort: 8080
-        # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes.
-        # This is an optional value and should be used based on the use case.
-        # This should be set only in case of eks, gke and other cloud providers. This option is should not be used for k8s and minikube.
-        # For example if you want to deploy a service of type LoadBalancer, specify serviceType: "LoadBalancer"
-        # serviceType: ""
-        # Specify the CIDR ranges to restrict the service access to the given CIDR range.
-        # Each new CIDR block should be added in a separate line.
-        # Should be used only when serviceType is set to LoadBalancer.
-        # Uncomment the following lines and replaces the CIDR blocks with your configuration requirements.
-        # loadBalancerSourceRanges:
-        #     - "123.123.123.0/24"
-        #     - "128.128.128.64/32"
         # To configure TLS between the ingress/load balancer and the backend, set the following:
         tls:
           enabled: false
@@ -174,6 +162,18 @@ global:
             serverName: ""
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
+        # Use this parameter to deploy a specific type of service using the serviceType parameter and specify the type of service in double quotes.
+        # This is an optional value and should be used based on the use case.
+        # This should be set only in case of eks, gke and other cloud providers. This option is should not be used for k8s and minikube.
+        # For example if you want to deploy a service of type LoadBalancer, specify serviceType: "LoadBalancer"
+        # serviceType: ""
+        # Specify the CIDR ranges to restrict the service access to the given CIDR range.
+        # Each new CIDR block should be added in a separate line.
+        # Should be used only when serviceType is set to LoadBalancer.
+        # Uncomment the following lines and replaces the CIDR blocks with your configuration requirements.
+        # loadBalancerSourceRanges:
+        #     - "123.123.123.0/24"
+        #     - "128.128.128.64/32"
 
       ingress:
         # For help configuring the ingress block including TLS, see the Helm chart documentation

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -174,7 +174,6 @@ global:
         # loadBalancerSourceRanges:
         #     - "123.123.123.0/24"
         #     - "128.128.128.64/32"
-        # loadBalancerSourceRanges:
 
       ingress:
         # For help configuring the ingress block including TLS, see the Helm chart documentation

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -165,9 +165,9 @@ global:
         serviceType: "LoadBalancer"
         # Specify the CIDR range inside the qoutations to restrict the service access to the given CIDR range
         # e.g "123.123.123.0/24"
-        loadBalancerSourceRanges: 
-        - "103.38.88.0/24"
-        - "49.43.219.90/32"
+        loadBalancerSourceRanges:
+          - "103.38.88.0/24"
+          - "49.43.219.90/32"
 
       ingress:
         # For help configuring the ingress block including TLS, see the Helm chart documentation

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -165,7 +165,7 @@ global:
         serviceType: "LoadBalancer"
         # Specify the CIDR range inside the qoutations to restrict the service access to the given CIDR range
         # e.g "123.123.123.0/24"
-        loadBalancerSourceRanges:
+        loadBalancerSourceRanges: 
         - "103.38.88.0/24"
         - "49.43.219.90/32"
 

--- a/terratest/src/test/pega/data/values_with_servicetype.yaml
+++ b/terratest/src/test/pega/data/values_with_servicetype.yaml
@@ -25,7 +25,7 @@ global:
             insecureSkipVerify: false
         serviceType: "LoadBalancer"
       ingress:
-        domain: 
+        domain:
         tls:
           enabled: true
           certificate:

--- a/terratest/src/test/pega/data/values_with_servicetype.yaml
+++ b/terratest/src/test/pega/data/values_with_servicetype.yaml
@@ -1,0 +1,49 @@
+---
+global:
+  tier:
+    - name: "web"
+      nodeType: "WebUser"
+      requestor:
+        passivationTimeSec: 900
+      service:
+        httpEnabled: true
+        port: 80
+        targetPort: 8080
+        tls:
+          enabled: false
+          external_secret_name: ""
+          keystore:
+          keystorepassword:
+          port: 443
+          targetPort: 8443
+          cacertificate:
+          certificateFile:
+          certificateKeyFile:
+          traefik:
+            enabled: false
+            serverName: ""
+            insecureSkipVerify: false
+        serviceType: "LoadBalancer"
+      ingress:
+        domain: 
+        tls:
+          enabled: true
+          certificate:
+          key:
+          cacertificate:
+      replicas: 1
+      javaOpts: ""
+      pegaDiagnosticUser: ""
+      pegaDiagnosticPassword: ""
+      deploymentStrategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      livenessProbe:
+        port: 8081
+      hpa:
+        enabled: true
+      pdb:
+        enabled: false
+        minAvailable: 1

--- a/terratest/src/test/pega/pega-tier-service-with-servicetype_test.go
+++ b/terratest/src/test/pega/pega-tier-service-with-servicetype_test.go
@@ -1,0 +1,45 @@
+package pega
+
+import (
+	"fmt"
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
+	k8score "k8s.io/api/core/v1"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPegaServiceWithServiceType(t *testing.T) {
+
+	var supportedVendors = []string{"openshift", "eks", "gke", "aks", "pks"}
+	var supportedOperations = []string{"install-deploy"}
+	var deploymentNames = []string{"pega", "myapp-dev"}
+
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	for _, vendor := range supportedVendors {
+		for _, operation := range supportedOperations {
+			for _, depName := range deploymentNames {
+				fmt.Println(vendor + "-" + operation)
+				var options = &helm.Options{
+					ValuesFiles: []string{"data/values_with_servicetype.yaml"},
+					SetValues: map[string]string{
+						"global.deployment.name":        depName,
+						"global.provider":               vendor,
+						"global.actions.execute":        operation,
+					},
+				}
+				yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-service.yaml"})
+				serviceyamlContent := strings.Split(yamlContent, "---")
+				var pegaServiceObj k8score.Service
+				UnmarshalK8SYaml(t, serviceyamlContent[1], &pegaServiceObj)
+				serviceType := pegaServiceObj.Spec.Type
+				require.Equal(t, k8score.ServiceType("LoadBalancer"), serviceType )
+			}
+        }
+	}
+}
+
+

--- a/terratest/src/test/pega/pega-tier-service_test.go
+++ b/terratest/src/test/pega/pega-tier-service_test.go
@@ -36,41 +36,12 @@ func TestPegaTierService(t *testing.T) {
 					},
 				}
 
-				var serviceTypeOptions = &helm.Options{
-					SetValues: map[string]string{
-						"global.deployment.name":        depName,
-						"global.provider":               vendor,
-						"global.actions.execute":        operation,
-						"global.tier[0].service.serviceType": "LoadBalancer",
-						"installer.upgrade.upgradeType": "zero-downtime",
-					},
-				}
-
 				yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-service.yaml"})
 				VerifyPegaServices(t, yamlContent, options)
-				yamlContentWithServiceType := RenderTemplate(t, serviceTypeOptions, helmChartPath, []string{"templates/pega-tier-service.yaml"})
-				VerifyPegaServicesWithServiceType(t, yamlContentWithServiceType, serviceTypeOptions)
 			}
 		}
 	}
 
-}
-
-func VerifyPegaServicesWithServiceType(t *testing.T, yamlContent string, serviceTypeOptions *helm.Options) {
-	var pegaServiceObj k8score.Service
-	serviceSlice := strings.Split(yamlContent, "---")
-	for index, serviceInfo := range serviceSlice {
-		if index >= 1 && index <= 2 {
-			UnmarshalK8SYaml(t, serviceInfo, &pegaServiceObj)
-
-			if index == 1 {
-				require.Equal(t, getObjName(serviceTypeOptions, "-web"), pegaServiceObj.ObjectMeta.Name)
-				require.Equal(t,pegaServiceObj.Spec.Type, k8score.ServiceType("LoadBalancer"))
-				VerifyPegaService(t, &pegaServiceObj, pegaServices{getObjName(serviceTypeOptions, "-web"), int32(80), intstr.IntOrString{IntVal: 8080}}, serviceTypeOptions)
-			} 
-		}
-	}
-	
 }
 
 // SplitAndVerifyPegaServices - Splits the services from the rendered template and asserts each service objects

--- a/terratest/src/test/pega/pega-tier-service_test.go
+++ b/terratest/src/test/pega/pega-tier-service_test.go
@@ -36,12 +36,41 @@ func TestPegaTierService(t *testing.T) {
 					},
 				}
 
+				var serviceTypeOptions = &helm.Options{
+					SetValues: map[string]string{
+						"global.deployment.name":        depName,
+						"global.provider":               vendor,
+						"global.actions.execute":        operation,
+						"global.tier[0].service.serviceType": "LoadBalancer",
+						"installer.upgrade.upgradeType": "zero-downtime",
+					},
+				}
+
 				yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-service.yaml"})
 				VerifyPegaServices(t, yamlContent, options)
+				yamlContentWithServiceType := RenderTemplate(t, serviceTypeOptions, helmChartPath, []string{"templates/pega-tier-service.yaml"})
+				VerifyPegaServicesWithServiceType(t, yamlContentWithServiceType, serviceTypeOptions)
 			}
 		}
 	}
 
+}
+
+func VerifyPegaServicesWithServiceType(t *testing.T, yamlContent string, serviceTypeOptions *helm.Options) {
+	var pegaServiceObj k8score.Service
+	serviceSlice := strings.Split(yamlContent, "---")
+	for index, serviceInfo := range serviceSlice {
+		if index >= 1 && index <= 2 {
+			UnmarshalK8SYaml(t, serviceInfo, &pegaServiceObj)
+
+			if index == 1 {
+				require.Equal(t, getObjName(serviceTypeOptions, "-web"), pegaServiceObj.ObjectMeta.Name)
+				require.Equal(t,pegaServiceObj.Spec.Type, k8score.ServiceType("LoadBalancer"))
+				VerifyPegaService(t, &pegaServiceObj, pegaServices{getObjName(serviceTypeOptions, "-web"), int32(80), intstr.IntOrString{IntVal: 8080}}, serviceTypeOptions)
+			} 
+		}
+	}
+	
 }
 
 // SplitAndVerifyPegaServices - Splits the services from the rendered template and asserts each service objects


### PR DESCRIPTION
Added the capability to specify the service type. Also added a capability to restrict access to specific IP CIDR blocks in case of a LoadBalancer service type.