### PR TITLE
🐛 fix(build): Added `external_secrets_name` condition for Cassandra auth

### DIFF
--- a/charts/pega/templates/_pega-credentials-secret.tpl
+++ b/charts/pega/templates/_pega-credentials-secret.tpl
@@ -35,9 +35,13 @@ data:
 
  {{ if (eq (include "performDeployment" .) "true") }}
   # Base64 encoded username for connecting to cassandra
+  {{ if .Values.dds.username -}}
   CASSANDRA_USERNAME: {{ .Values.dds.username | b64enc }}
+  {{- end }}
   # Base64 encoded password for connecting to cassandra
+  {{ if .Values.dds.password -}}
   CASSANDRA_PASSWORD: {{ .Values.dds.password | b64enc }}
+  {{- end }}
   {{ if .Values.dds.trustStorePassword -}}
   # Base64 encoded password for the cassandra trust store
   CASSANDRA_TRUSTSTORE_PASSWORD: {{ .Values.dds.trustStorePassword | b64enc }}


### PR DESCRIPTION
When providing values to the username and password via templating, the `CASSANDRA_USERNAME` and `CASSANDRA_PASSWORD` environment variable instantiation portion of the the template does not check for `external_secrets_name`, e.g. the JDBC connection. This causes a crash of Pega docker images in a kubernetes environment if the engineer uses `external_secrets_name` in the DDS block of `values.yaml`.

Simply adding the same `if` logic from the JDBC portion of the code fixes this and allows the chart to finish templating `server.xml.tpl` and other required tomcat files given deployments which have pre-existing secrets, or ones being added to `./templates/`.