### PR TITLE
Only set custom.jvm.args if CUSTOM_JVM_ARGS is set

### DIFF
--- a/charts/pega/charts/installer/config/setupDatabase.properties.tmpl
+++ b/charts/pega/charts/installer/config/setupDatabase.properties.tmpl
@@ -86,6 +86,6 @@ bypass.load.assembled.classes={{ .Env.BYPASS_LOAD_ASSEMBLED_CLASSES }}
 # Enable adminstrator user after upgrade by default.
 upgrade.enable.admin=true
 
-custom.jvm.args={{ .Env.CUSTOM_JVM_ARGS }}
+custom.jvm.args={{ default .Env.CUSTOM_JVM_ARGS "-Xmx4g" }}
 
 {{ .Env.ADVANCED_SETTINGS }}

--- a/charts/pega/charts/installer/config/setupDatabase.properties.tmpl
+++ b/charts/pega/charts/installer/config/setupDatabase.properties.tmpl
@@ -86,6 +86,8 @@ bypass.load.assembled.classes={{ .Env.BYPASS_LOAD_ASSEMBLED_CLASSES }}
 # Enable adminstrator user after upgrade by default.
 upgrade.enable.admin=true
 
-custom.jvm.args={{ default .Env.CUSTOM_JVM_ARGS "-Xmx4g" }}
+{{- if .Env.CUSTOM_JVM_ARGS }}
+custom.jvm.args={{ .Env.CUSTOM_JVM_ARGS }}
+{{- end }}
 
 {{ .Env.ADVANCED_SETTINGS }}


### PR DESCRIPTION
The installer setting custom.jvm.args requires setting the max heap size if provided. Currently CUSTOM_JVM_ARGS is not set by default, so the installer is passed custom.jvm.args which bypasses the default max heap size in the installer.

Conditionalize the inclusion of custom.jvm.args bsaed on whether it is actually being configured.