### PR TITLE
Updated Hazelcast heap setting to derive from available RAM

### DIFF
--- a/charts/pega/charts/hazelcast/values.yaml
+++ b/charts/pega/charts/hazelcast/values.yaml
@@ -38,8 +38,8 @@ client:
   clusterName: "PRPC"
 # Server side settings for Hazelcast
 server:
-  java_opts: "-Xms820m -Xmx820m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/hazelcast/logs/heapdump.hprof
-  -XX:+UseParallelGC -Xlog:gc*,gc+phases=debug:file=/opt/hazelcast/logs/gc.log:time,pid,tags:filecount=5,filesize=3m"
+  java_opts: "-XX:MaxRAMPercentage=80.0 -XX:InitialRAMPercentage=80.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/hazelcast/logs/heapdump.hprof
+  -XX:+UseParallelGC -Xlog:gc*,gc+phases=debug:file=/opt/hazelcast/logs/gc.log:time,pid,tags:filecount=5,filesize=3m -XshowSettings:vm"
   jmx_enabled: "true"
   health_monitoring_level: "OFF"
   operation_generic_thread_count: ""

--- a/terratest/src/test/pega/clustering-service-environment-config_test.go
+++ b/terratest/src/test/pega/clustering-service-environment-config_test.go
@@ -49,7 +49,7 @@ func VerifyClusteringServiceEnvironmentConfig(t *testing.T, yamlContent string, 
 			UnmarshalK8SYaml(t, statefulInfo, &clusteringServiceEnvConfigMap)
 			clusteringServiceEnvConfigData := clusteringServiceEnvConfigMap.Data
 			require.Equal(t, clusteringServiceEnvConfigData["NAMESPACE"], "default")
-			require.Equal(t, clusteringServiceEnvConfigData["JAVA_OPTS"], "-Xms820m -Xmx820m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/hazelcast/logs/heapdump.hprof -XX:+UseParallelGC -Xlog:gc*,gc+phases=debug:file=/opt/hazelcast/logs/gc.log:time,pid,tags:filecount=5,filesize=3m")
+			require.Equal(t, clusteringServiceEnvConfigData["JAVA_OPTS"], "-XX:MaxRAMPercentage=80.0 -XX:InitialRAMPercentage=80.0 -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/hazelcast/logs/heapdump.hprof -XX:+UseParallelGC -Xlog:gc*,gc+phases=debug:file=/opt/hazelcast/logs/gc.log:time,pid,tags:filecount=5,filesize=3m -XshowSettings:vm")
 			require.Equal(t, clusteringServiceEnvConfigData["SERVICE_NAME"], "clusteringservice-service")
 			require.Equal(t, clusteringServiceEnvConfigData["MIN_CLUSTER_SIZE"], "3")
             require.Equal(t, clusteringServiceEnvConfigData["JMX_ENABLED"], "true")


### PR DESCRIPTION
Updated Hazelcast heap setting to derive from available RAM

Changed the literal value to % so that it can be derived based on provided memory to the container.

Default from HZ : https://github.com/hazelcast/hazelcast-docker/blob/master/hazelcast-enterprise/Dockerfile#L16
