### PR TITLE
US-530858: Helm chart and documentation updates for updating to elasticsearch 8.x version

### DIFF
--- a/charts/backingservices/charts/srs/README.md
+++ b/charts/backingservices/charts/srs/README.md
@@ -20,7 +20,7 @@ The service deployment provisions runtime service pods along with a dependency o
         <tr>
             <th>Pega Infinity version</th>
             <th>SRS version</th>
-            <th>K8's version</th>
+            <th>Kubernetes version</th>
             <th>Authentication</th>
             <th>Certified Elasticsearch version</th>
             <th>Description</th>
@@ -37,55 +37,54 @@ The service deployment provisions runtime service pods along with a dependency o
         </tr>
         <tr>
             <td rowspan=4> >= 8.6 </td>
-            <td rowspan=4>1.28</td>
+            <td rowspan=4>1.29</td>
             <td rowspan=2>< 1.25</td>
             <td>No Authentication</td>
             <td>7.10.2, 7.16.3 & 7.17.9</td>
-            <td>Pega recommends using Elasticsearch version 7.17.9.</td>
+            <td>As a best practice, use Elasticsearch version 7.17.9.</td>
         </tr>
         <tr>
             <td>Basic Authentication</td>
             <td>7.10.2, 7.16.3, 7.17.9 & 8.10.3</td>
-            <td>Pega recommends using Elasticsearch version 8.10.3.</td>
+            <td>As a best practice, use Elasticsearch version 8.10.3.</td>
         </tr>
         <tr>
             <td rowspan=2>>= 1.25</td>
             <td>No Authentication</td>
             <td>7.16.3 & 7.17.9</td>
-            <td>Pega recommends using Elasticsearch version 7.17.9.</td>
+            <td>As a best practice, use Elasticsearch version 7.17.9.</td>
         </tr>
         <tr>
             <td>Basic Authentication</td>
             <td>7.16.3, 7.17.9 & 8.10.3</td>
-            <td>Pega recommends using Elasticsearch version 8.10.3.</td>
-        </tr>
-        <tr>
-            <td colspan=6>Note:  To stay current with Pega releases, use the latest available SRS image v1.28</td>
+            <td>As a best practice, use Elasticsearch version 8.10.3.</td>
         </tr>
     </tbody>
 </table>
 
-**Note**: 
+**Note:**
 
 ### If your deployment uses the internally-provisioned Elasticsearch: ###
-To migrate to Elasticsearch version 7.17.9 or 8.10.3 from the Elasticsearch version 7.10.2 or 7.16.3 follow below steps that applies to your deployment:
-#### Step 1: Update the SRS Docker image version to use v1.28, which supports both Elasticsearch versions 7.10.x and 7.16.x.
-#### Step 2: Update Elasticsearch version to 7.17.9 as follows ###
+To migrate to Elasticsearch version 7.17.9 or 8.10.3 from the Elasticsearch version 7.10.2 or 7.16.3, perform the following steps:
+1. Update the SRS Docker image version to use v1.29, which supports both Elasticsearch versions 7.10.x and 7.16.x.
+2. To update Elasticsearch version to 7.17.9 perform the following actions:
     * Update the Elasticsearch `dependencies.version` parameter in the [requirement.yaml](../../requirements.yaml) to 7.17.3.
-    * Update Elasticsearch to 7.17.9.
-***Stop here if you don't want to upgrade Elasticsearch version to 8.10.3 or else continue***
-#### Step 3: Update Elasticsearch version to 8.10.3 as follows  ###
+    
+      Note: This parameter references the Elasticsearch Helm chart version and not the Elasticsearch cluster version.  
+    * Update the elasticsearch.imageTag in the Backing Services Helm chart to 7.17.9.
+3. To update Elasticsearch version to 8.10.3, perform the following actions:
     * Update the Elasticsearch `dependencies.version` parameter in the [requirement.yaml](../../requirements.yaml) to 8.5.1.
-    * Update Elasticsearch to 8.10.3.
-#### Step 4: Restart the SRS pods  ####
+
+      Note: This parameter references the Elasticsearch Helm chart version and not the Elasticsearch cluster version.
+    * Update the elasticsearch.imageTag in the Backing Services Helm chart to 8.10.3.
+4. Restart the SRS pods
 
 ### If your deployment connects to an externally-managed Elasticsearch service: ###
-To migrate to Elasticsearch version 7.17.9 or 8.10.3 from the Elasticsearch version 7.10.2 or 7.16.3 follow below steps that applies to your deployment:
-#### Step 1: Update the SRS Docker image version to use v1.28, which supports both Elasticsearch versions 7.10.x and 7.16.x.
-#### Step 2: Complete the version upgrade to 7.17.9. Refer to Elasticsearch version 7.17 documentation. For example, see [Upgrade Elasticsearch to 7.17](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/setup-upgrade.html). ###
-***Stop here if you don't want to upgrade Elasticsearch version to 8.10.3 or else continue***
-#### Step 3: Complete the version upgrade to 8.10.3. Refer to Elasticsearch version 8.10 documentation. For example, see [Upgrade Elasticsearch to 8.10](https://www.elastic.co/guide/en/elasticsearch/reference/8.10/setup-upgrade.html). ###
-#### Step 4: Restart the SRS pods  ####
+To migrate to Elasticsearch version 7.17.9 or 8.10.3 from the Elasticsearch version 7.10.2 or 7.16.3, perform the following steps:
+1. Update the SRS Docker image version to use v1.29, which supports Elasticsearch versions 7.10.x and 7.16.x.
+2. To use Elasticsearch version 7.17.9, upgrade your external Elasticsearch cluster to 7.17.9 according to your organization’s best practices. For more information, see official Elasticsearch version 7.17 documentation.
+3. To use Elasticsearch version 8.10.3, upgrade your external Elasticsearch cluster to 8.10.3 according to your organization’s best practices. For more information, see official Elasticsearch version 8.10 documentation.
+4. Restart the SRS pods
 
 ### SRS runtime configuration
 

--- a/charts/backingservices/charts/srs/README.md
+++ b/charts/backingservices/charts/srs/README.md
@@ -15,23 +15,77 @@ The service deployment provisions runtime service pods along with a dependency o
 
 ### SRS Version compatibility matrix
 
-| Pega Infinity version | SRS version | Elasticsearch version | Description                                                                                                                                                                                                                                                                                                           |
-|-----------------------|-------------|-----------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| < 8.6                 | NA          | NA                    | SRS can be used with Pega Infinity 8.6 and later                                                                                                                                                                                                                                                                      |
-| \>= 8.6              | 1.28.0      | 7.10.2, 7.16.3, and 7.17.9      | While SRS Docker images are certified against Elasticsearch versions 7.10.2, 7.16.3 and 7.17.9, Pega recommends using Elasticsearch version 7.17.9. To stay current with Pega releases, use the latest available SRS image 1.28.0.
+<table>
+    <thead>
+        <tr>
+            <th>Pega Infinity version</th>
+            <th>SRS version</th>
+            <th>K8's version</th>
+            <th>Authentication</th>
+            <th>Certified Elasticsearch version</th>
+            <th>Description</th>
+        </tr>
+    </thead>
+    <tbody>
+        <tr>
+            <td>< 8.6</td>
+            <td>NA</td>
+            <td>NA</td>
+            <td>NA</td>
+            <td>NA</td>
+            <td>SRS can be used with Pega Infinity 8.6 and later</td>
+        </tr>
+        <tr>
+            <td rowspan=4> >= 8.6 </td>
+            <td rowspan=4>1.28</td>
+            <td rowspan=2>< 1.25</td>
+            <td>No Authentication</td>
+            <td>7.10.2, 7.16.3 & 7.17.9</td>
+            <td>Pega recommends using Elasticsearch version 7.17.9.</td>
+        </tr>
+        <tr>
+            <td>Basic Authentication</td>
+            <td>7.10.2, 7.16.3, 7.17.9 & 8.10.3</td>
+            <td>Pega recommends using Elasticsearch version 8.10.3.</td>
+        </tr>
+        <tr>
+            <td rowspan=2>>= 1.25</td>
+            <td>No Authentication</td>
+            <td>7.16.3 & 7.17.9</td>
+            <td>Pega recommends using Elasticsearch version 7.17.9.</td>
+        </tr>
+        <tr>
+            <td>Basic Authentication</td>
+            <td>7.16.3, 7.17.9 & 8.10.3</td>
+            <td>Pega recommends using Elasticsearch version 8.10.3.</td>
+        </tr>
+        <tr>
+            <td colspan=6>Note:  To stay current with Pega releases, use the latest available SRS image v1.28</td>
+        </tr>
+    </tbody>
+</table>
 
 **Note**: 
 
-**If your deployment uses the internally-provisioned Elasticsearch:** To migrate to Elasticsearch version 7.17.9 from the Elasticsearch version 7.10.2 or 7.16.3 use the process that applies to your deployment:
+### If your deployment uses the internally-provisioned Elasticsearch: ###
+To migrate to Elasticsearch version 7.17.9 or 8.10.3 from the Elasticsearch version 7.10.2 or 7.16.3 follow below steps that applies to your deployment:
+#### Step 1: Update the SRS Docker image version to use v1.28, which supports both Elasticsearch versions 7.10.x and 7.16.x.
+#### Step 2: Update Elasticsearch version to 7.17.9 as follows ###
+    * Update the Elasticsearch `dependencies.version` parameter in the [requirement.yaml](../../requirements.yaml) to 7.17.3.
+    * Update Elasticsearch to 7.17.9.
+***Stop here if you don't want to upgrade Elasticsearch version to 8.10.3 or else continue***
+#### Step 3: Update Elasticsearch version to 8.10.3 as follows  ###
+    * Update the Elasticsearch `dependencies.version` parameter in the [requirement.yaml](../../requirements.yaml) to 8.5.1.
+    * Update Elasticsearch to 8.10.3.
+#### Step 4: Restart the SRS pods  ####
 
-* Update the SRS Docker image version to use v1.28.0, which supports both Elasticsearch versions 7.10.x and 7.16.x.
-* Update the Elasticsearch `dependencies.version` parameter in the [requirement.yaml](../../requirements.yaml) to 7.17.3.
-* Update Elasticsearch to 7.17.9.
-
-**If your deployment connects to an externally-managed Elasticsearch service:** To migrate to Elasticsearch version 7.17.9 from the Elasticsearch version 7.10.2 or 7.16.3 use the process that applies to your deployment:
-
-* Update the SRS Docker image version to use v1.28.0, which supports both Elasticsearch versions 7.10.x and 7.16.x.
-* Complete the version upgrade to 7.17.9. Refer to Elasticsearch version 7.17 documentation. For example, see [Upgrade Elasticsearch](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/setup-upgrade.html).
+### If your deployment connects to an externally-managed Elasticsearch service: ###
+To migrate to Elasticsearch version 7.17.9 or 8.10.3 from the Elasticsearch version 7.10.2 or 7.16.3 follow below steps that applies to your deployment:
+#### Step 1: Update the SRS Docker image version to use v1.28, which supports both Elasticsearch versions 7.10.x and 7.16.x.
+#### Step 2: Complete the version upgrade to 7.17.9. Refer to Elasticsearch version 7.17 documentation. For example, see [Upgrade Elasticsearch to 7.17](https://www.elastic.co/guide/en/elasticsearch/reference/7.17/setup-upgrade.html). ###
+***Stop here if you don't want to upgrade Elasticsearch version to 8.10.3 or else continue***
+#### Step 3: Complete the version upgrade to 8.10.3. Refer to Elasticsearch version 8.10 documentation. For example, see [Upgrade Elasticsearch to 8.10](https://www.elastic.co/guide/en/elasticsearch/reference/8.10/setup-upgrade.html). ###
+#### Step 4: Restart the SRS pods  ####
 
 ### SRS runtime configuration
 

--- a/charts/backingservices/charts/srs/README.md
+++ b/charts/backingservices/charts/srs/README.md
@@ -37,7 +37,7 @@ The service deployment provisions runtime service pods along with a dependency o
         </tr>
         <tr>
             <td rowspan=4> >= 8.6 </td>
-            <td rowspan=4>1.29</td>
+            <td rowspan=4>1.29.1</td>
             <td rowspan=2>< 1.25</td>
             <td>No Authentication</td>
             <td>7.10.2, 7.16.3 & 7.17.9</td>
@@ -66,7 +66,7 @@ The service deployment provisions runtime service pods along with a dependency o
 
 ### If your deployment uses the internally-provisioned Elasticsearch: ###
 To migrate to Elasticsearch version 7.17.9 or 8.10.3 from the Elasticsearch version 7.10.2 or 7.16.3, perform the following steps:
-1. Update the SRS Docker image version to use v1.29, which supports both Elasticsearch versions 7.10.x and 7.16.x.
+1. Update the SRS Docker image version to use v1.29.1. This version has backward compatibility with Elasticsearch versions 7.10.x and 7.16.x, so your SRS will continue to work even before you update your Elasticsearch service.
 2. To update Elasticsearch version to 7.17.9 perform the following actions:
     * Update the Elasticsearch `dependencies.version` parameter in the [requirement.yaml](../../requirements.yaml) to 7.17.3.
     
@@ -81,7 +81,7 @@ To migrate to Elasticsearch version 7.17.9 or 8.10.3 from the Elasticsearch vers
 
 ### If your deployment connects to an externally-managed Elasticsearch service: ###
 To migrate to Elasticsearch version 7.17.9 or 8.10.3 from the Elasticsearch version 7.10.2 or 7.16.3, perform the following steps:
-1. Update the SRS Docker image version to use v1.29, which supports Elasticsearch versions 7.10.x and 7.16.x.
+1. Update the SRS Docker image version to use v1.29.1. This version has backward compatibility with Elasticsearch versions 7.10.x and 7.16.x, so your SRS will continue to work even before you update your Elasticsearch service.
 2. To use Elasticsearch version 7.17.9, upgrade your external Elasticsearch cluster to 7.17.9 according to your organization’s best practices. For more information, see official Elasticsearch version 7.17 documentation.
 3. To use Elasticsearch version 8.10.3, upgrade your external Elasticsearch cluster to 8.10.3 according to your organization’s best practices. For more information, see official Elasticsearch version 8.10 documentation.
 4. Restart the SRS pods

--- a/charts/backingservices/charts/srs/templates/_helpers.tpl
+++ b/charts/backingservices/charts/srs/templates/_helpers.tpl
@@ -166,11 +166,16 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 
 {{- define "esDeploymentPassword" -}}
 {{- if and (.Values.srsStorage.tls.enabled) (not .Values.srsStorage.provisionInternalESCluster) (not .Values.srsStorage.basicAuthentication.enabled) (not .Values.srsStorage.awsIAM)}}
-{{- .Values.srsStorage.esCredentials.password  |  b64enc }}
+{{- .Values.srsStorage.esCredentials.password | b64enc }}
 {{- else if and (.Values.srsStorage.basicAuthentication.enabled) (not .Values.srsStorage.provisionInternalESCluster) (not .Values.srsStorage.tls.enabled) }}
-{{- .Values.srsStorage.esCredentials.password  |  b64enc }}
+{{- .Values.srsStorage.esCredentials.password | b64enc }}
 {{- else if and (.Values.srsStorage.provisionInternalESCluster) (not .Values.srsStorage.awsIAM) }}
+{{- $secret := (lookup "v1" "Secret" .Release.Namespace "srs-elastic-credentials") }}
+{{- if $secret }}
+{{- index $secret.data "password" }}
+{{- else}}
 {{- randAlphaNum 20 | b64enc}}
+{{- end -}}
 {{- end}}
 {{- end}}
 

--- a/charts/backingservices/values.yaml
+++ b/charts/backingservices/values.yaml
@@ -18,7 +18,7 @@ srs:
   # Configure the location of the busybox image that is used during the deployment process of
   # the internal Elasticsearch cluster
   busybox:
-    image: "alpine:3.16.1"
+    image: "alpine:3.18.3"
     imagePullPolicy: "IfNotPresent"
 
   srsRuntime:
@@ -86,8 +86,8 @@ constellation:
 # based on helm charts defined at https://github.com/elastic/helm-charts/tree/master/elasticsearch and may be modified
 # as per runtime and storage requirements.
 elasticsearch:
-  # For internally provisioned Elasticsearch server, the imageTag parameter is set by default to 7.17.9, which is the recommended Elasticsearch server version
-  # for k8s version >= 1.25.
+  # For internally provisioned Elasticsearch server, the imageTag parameter is set by default to 7.17.9, which is the
+  # recommended Elasticsearch server version for k8s version >= 1.25.
   # Use this parameter to change it to 7.10.2 or 7.16.3 for k8s version < 1.25 and make sure to update the Elasticsearch helm chart version in requirements.yaml.
   imageTag: 7.17.9
   # Permit co-located instances for solitary minikube virtual machines.
@@ -99,6 +99,12 @@ elasticsearch:
   # If you previously set srs.srsStorage.tls.enabled: true, you must uncomment the line to use protocol: https parameter.
   # protocol: https
 
+  # Uncomment the below lines if you want to deploy/upgrade Elasticsearch server version >= 8.x
+  # createCert: false
+  # secret:
+  #   enabled: false
+  # protocol: http
+
   # For deployments that use TLS-based authentication to an internal Elasticsearch service in the SRS cluster,
   # uncomment and appropriately add below lines under esConfig.elasticsearch.yml.
   # xpack.security.http.ssl.enabled: true
@@ -107,11 +113,14 @@ elasticsearch:
 
   esConfig:
     elasticsearch.yml: |
-     xpack.security.enabled: true
-     xpack.security.transport.ssl.enabled: true
-     xpack.security.transport.ssl.verification_mode: certificate
-     xpack.security.transport.ssl.keystore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
-     xpack.security.transport.ssl.truststore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+      xpack.security.enabled: true
+      xpack.security.transport.ssl.enabled: true
+      xpack.security.transport.ssl.verification_mode: certificate
+      xpack.security.transport.ssl.keystore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+      xpack.security.transport.ssl.truststore.path: /usr/share/elasticsearch/config/certs/elastic-certificates.p12
+    # Uncomment the below lines if you want to deploy/upgrade Elasticsearch server version >= 8.x by adding below lines under esConfig.elasticsearch.yml.
+    # action.destructive_requires_name: false
+    # ingest.geoip.downloader.enabled: false
 
   # Use this section to include additional, supported environmental variables for Elasticsearch basic authentication.
   # The parameter values can be read from a specified secrets file.


### PR DESCRIPTION
Helm chart and documentation updates for updating to elasticsearch 8.x version