### PR TITLE
make installer PDB a hook to avoid conflicts with upgrade jobs

### DIFF
--- a/charts/pega/charts/installer/templates/pega-installer-pdb.yaml
+++ b/charts/pega/charts/installer/templates/pega-installer-pdb.yaml
@@ -3,6 +3,9 @@ apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: "installer-job-pdb"
+  annotations:
+    "helm.sh/hook": pre-install, pre-upgrade
+    "helm.sh/hook-delete-policy": before-hook-creation
 spec:
   minAvailable: 1
   selector:


### PR DESCRIPTION
In some scenarios install charts may be deployed twice, once for install and once for upgrade. This leads to a conflict on the installer PDB which is used for both.

This PR makes the PDB a hook to avoid that conflict.