### PR TITLE
ISSUE-125040: Exposed custom ports for service

### DIFF
--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -1396,3 +1396,29 @@ behavior:
    scaleUp:
       stabilizationWindowSeconds: << provide scaleUp stabilization window in seconds >>
 ```
+
+### Custom Ports
+
+Pega supports configuring custom ports for deployments and services.
+
+To configure custom ports for deployment, please add the below configuration for applicable tiers
+```yaml
+tier:
+  - name: my-tier
+    custom:
+      ports:
+        - name: portName
+          containerPort: portId
+```
+
+To configure custom ports for service, please add the below configuration for applicable services
+```yaml
+tier:
+   - name: my-tier
+     service:
+       customServicePorts:
+       - name: portName
+         port: portId
+         targetPort: targetPort
+          
+```

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -1399,26 +1399,25 @@ behavior:
 
 ### Custom Ports
 
-Pega supports configuring custom ports for deployments and services.
+You can optionally specify custom ports for deployment tier. You can specify custom ports for your tiers as shown in the example below:
 
-To configure custom ports for deployment, please add the below configuration for applicable tiers
 ```yaml
 tier:
   - name: my-tier
     custom:
       ports:
-        - name: portName
-          containerPort: portId
+        - name: <name>
+          containerPort: <port>
 ```
 
-To configure custom ports for service, please add the below configuration for applicable services
+You can optionally specify custom ports for tier specific service. You can specify custom ports for your service as shown in the example below:
 ```yaml
 tier:
    - name: my-tier
      service:
        customServicePorts:
-       - name: portName
-         port: portId
-         targetPort: targetPort
+       - name: <name>
+         port: <port>
+         targetPort: <target port>
           
 ```

--- a/charts/pega/templates/_pega-service.tpl
+++ b/charts/pega/templates/_pega-service.tpl
@@ -61,6 +61,9 @@ spec:
     port: {{ .node.service.tls.port }}
     targetPort: {{ .node.service.tls.targetPort }}
 {{- end }}
+{{- if .node.service.customServicePorts }}
+{{ toYaml .node.service.customServicePorts | indent 2 }}
+{{- end }}
   selector:
     app: {{ .name }}
 ---

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -195,6 +195,13 @@ global:
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
 
+        # Define custom ports for service here. If you want to use the custom ports for other services, please use the same configuration for those services.
+        # customServicePorts:
+        # - name: <name>
+        #   port: <port>
+        #   targetPort: <port>
+
+
       ingress:
         enabled: true
         # For help configuring the ingress block including TLS, see the Helm chart documentation

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -163,6 +163,13 @@ global:
         # loadBalancerSourceRanges:
         #     - "123.123.123.0/24"
         #     - "128.128.128.64/32"
+
+        # Define custom ports for service here. If you want to use the custom ports for other services, please use the same configuration for those services.
+        # customServicePorts:
+        # - name: <name>
+        #   port: <port>
+        #   targetPort: <port>
+
         # To configure TLS between the ingress/load balancer and the backend, set the following:
         tls:
           enabled: false
@@ -194,13 +201,6 @@ global:
             serverName: ""
             # set insecureSkipVerify=true, if the certificate verification has to be skipped
             insecureSkipVerify: false
-
-        # Define custom ports for service here. If you want to use the custom ports for other services, please use the same configuration for those services.
-        # customServicePorts:
-        # - name: <name>
-        #   port: <port>
-        #   targetPort: <port>
-
 
       ingress:
         enabled: true

--- a/terratest/src/test/pega/data/values_service_custom_ports.yaml
+++ b/terratest/src/test/pega/data/values_service_custom_ports.yaml
@@ -1,0 +1,52 @@
+---
+global:
+  tier:
+    - name: "web"
+      nodeType: "WebUser"
+      requestor:
+        passivationTimeSec: 900
+      service:
+        httpEnabled: true
+        port: 80
+        targetPort: 8080
+        tls:
+          enabled: false
+          external_secret_name: ""
+          keystore:
+          keystorepassword:
+          port: 443
+          targetPort: 8443
+          cacertificate:
+          certificateFile:
+          certificateKeyFile:
+          traefik:
+            enabled: false
+            serverName: ""
+            insecureSkipVerify: false
+        customServicePorts:
+          - name: port1
+            port: 5005
+            targetPort: 5005
+      ingress:
+        domain:
+        tls:
+          enabled: true
+          certificate:
+          key:
+          cacertificate:
+      replicas: 1
+      javaOpts: ""
+      pegaDiagnosticUser: ""
+      pegaDiagnosticPassword: ""
+      deploymentStrategy:
+        rollingUpdate:
+          maxSurge: 1
+          maxUnavailable: 0
+        type: RollingUpdate
+      livenessProbe:
+        port: 8081
+      hpa:
+        enabled: true
+      pdb:
+        enabled: false
+        minAvailable: 1


### PR DESCRIPTION
Custom ports are configured for deployments. To access them from outside the cluster, we need services to be created. Added custom ports configuration for k8s service.