### PR TITLE
US-625432 Allow to configure securityContext for Pega containers

### DIFF
--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -214,6 +214,10 @@ spec:
         envFrom:
         - configMapRef:
             name: {{ template "pegaEnvironmentConfig" .root }}
+{{- if .node.containerSecurityContext }}
+        securityContext:
+{{ toYaml .node.containerSecurityContext | indent 10 }}
+{{-  end }}
         resources:
 {{- if .node.resources }}
 {{ toYaml .node.resources | indent 10 }}

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -263,8 +263,8 @@ global:
       # do not affect the Pod's Volumes.
       # See, https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
       # containerSecurityContext:
-      #   runAsUser: 7009
-      #   fsGroup: 0
+      #   capabilities:
+      #     add: ["SYS_TIME"]
       hpa:
         enabled: true
         # To configure behavior specifications for hpa, set the required scaleUp & scaleDown values.
@@ -333,8 +333,8 @@ global:
       # do not affect the Pod's Volumes.
       # See, https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
       # containerSecurityContext:
-      #   runAsUser: 7009
-      #   fsGroup: 0
+      #   capabilities:
+      #     add: ["SYS_TIME"]
 
       hpa:
         enabled: true
@@ -404,8 +404,8 @@ global:
       # do not affect the Pod's Volumes.
       # See, https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
       # containerSecurityContext:
-      #   runAsUser: 7009
-      #   fsGroup: 0
+      #   capabilities:
+      #     add: ["SYS_TIME"]
 
       replicas: 2
 

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -257,6 +257,14 @@ global:
       #   runAsUser: 9001
       #   fsGroup: 0
 
+      # To specify security settings for a Container, include the securityContext field in the Container manifest
+      # Security settings that you specify for a Container apply only to the pega container,
+      # and they override settings made at the Pod level when there is overlap. Container settings
+      # do not affect the Pod's Volumes.
+      # See, https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+      # containerSecurityContext:
+      #   runAsUser: 7009
+      #   fsGroup: 0
       hpa:
         enabled: true
         # To configure behavior specifications for hpa, set the required scaleUp & scaleDown values.
@@ -319,6 +327,15 @@ global:
       #   runAsUser: 9001
       #   fsGroup: 0
 
+      # To specify security settings for a Container, include the securityContext field in the Container manifest
+      # Security settings that you specify for a Container apply only to the pega container,
+      # and they override settings made at the Pod level when there is overlap. Container settings
+      # do not affect the Pod's Volumes.
+      # See, https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+      # containerSecurityContext:
+      #   runAsUser: 7009
+      #   fsGroup: 0
+
       hpa:
         enabled: true
 
@@ -379,6 +396,15 @@ global:
       # See, https://github.com/pegasystems/pega-helm-charts/blob/master/charts/pega/README.md#security-context
       # securityContext:
       #   runAsUser: 9001
+      #   fsGroup: 0
+
+      # To specify security settings for a Container, include the securityContext field in the Container manifest
+      # Security settings that you specify for a Container apply only to the pega container,
+      # and they override settings made at the Pod level when there is overlap. Container settings
+      # do not affect the Pod's Volumes.
+      # See, https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container
+      # containerSecurityContext:
+      #   runAsUser: 7009
       #   fsGroup: 0
 
       replicas: 2

--- a/terratest/src/test/pega/pega-tier-deployment_container_security_context_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment_container_security_context_test.go
@@ -1,0 +1,85 @@
+package pega
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+func TestPegaTierDeploymentContainerSecurityContext(t *testing.T) {
+	var supportedVendors = []string{"k8s", "openshift", "eks", "gke", "aks", "pks"}
+	var supportedOperations = []string{"deploy"}
+	var deploymentNames = []string{"myapp-dev"}
+
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	for _, vendor := range supportedVendors {
+
+		var depObj appsv1.Deployment
+
+		for _, operation := range supportedOperations {
+
+			for _, depName := range deploymentNames {
+
+				fmt.Println(vendor + "-" + operation)
+
+				var options = &helm.Options{
+					SetValues: map[string]string{
+						"global.provider":        vendor,
+						"global.actions.execute": operation,
+						"global.deployment.name": depName,
+					},
+				}
+
+				yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+				yamlSplit := strings.Split(yamlContent, "---")
+				UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+				require.Nil(t, depObj.Spec.Template.Spec.Containers[0].SecurityContext)
+
+			}
+		}
+	}
+}
+
+func TestPegaTierDeploymentSecurityContextForPegaContainer(t *testing.T) {
+	var supportedVendors = []string{"k8s", "openshift"}
+	var supportedOperations = []string{"deploy"}
+	var deploymentNames = []string{"myapp-dev"}
+
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	for _, vendor := range supportedVendors {
+
+		var depObj appsv1.Deployment
+
+		for _, operation := range supportedOperations {
+
+			for _, depName := range deploymentNames {
+
+				fmt.Println(vendor + "-" + operation)
+
+				var options = &helm.Options{
+					SetValues: map[string]string{
+						"global.provider":                                   vendor,
+						"global.actions.execute":                            operation,
+						"global.deployment.name":                            depName,
+						"global.tier[0].containerSecurityContext.runAsUser": "7009",
+					},
+				}
+
+				yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+				yamlSplit := strings.Split(yamlContent, "---")
+				UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+
+				require.Equal(t, int64(7009), *depObj.Spec.Template.Spec.Containers[0].SecurityContext.RunAsUser)
+			}
+		}
+	}
+}


### PR DESCRIPTION
Allow to configure securityContext for Pega tier containers to specify security settings for a Container, include the securityContext field in the Container manifest. 

Note that the Security settings that you specify for a Container apply only to the Pega container, and they override settings made at the Pod level when there is overlap. Container settings do not affect the Pod's Volumes.
See, https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-container