### PR TITLE
US-654940 - Remove docs-previous links from github readmes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Pega deployment on Kubernetes
 
-This project provides Helm charts and basic examples for deploying Pega on Kubernetes. You will also need to download the required [installation kit](https://community.pega.com/knowledgebase/products/platform/deploy) from the Pega Community which includes rules and data to preload into your relational database. Deploying Pega on Kubernetes requires Pega Infinity 8.3 or later.
+This project provides Helm charts and basic examples for deploying Pega on Kubernetes. You will also need to download the required [Pega-provided Docker images](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html) which include rules and data to preload into your relational database. Deploying Pega on Kubernetes requires Pega Infinity 8.3 or later.
 
 [![Build Status](https://github.com/pegasystems/pega-helm-charts/actions/workflows/github-actions-build.yml/badge.svg)](https://github.com/pegasystems/pega-helm-charts/actions/workflows/github-actions-build.yml)
 [![GitHub release](https://img.shields.io/github/release/pegasystems/pega-helm-charts.svg)](https://github.com/pegasystems/pega-helm-charts/releases)
@@ -79,7 +79,7 @@ $ helm inspect values pega/backingservices > backingservices.yaml
 * [Instructions to configure the Pega addons](charts/addons/README.md)
 * [Instructions to configure the Pega backingservices](charts/backingservices/README.md)
 
-When making customizations for your environment, check the [Pega Platform Support Guide Resources](https://community.pega.com/knowledgebase/articles/pega-platform-support-guide-resources) to verify that those changes are supported by your Pega Platform version.
+When making customizations for your environment, check the [Pega Platform Support Guide](https://docs.pega.com/bundle/platform/page/platform/deployment/platform-support-guide/platform-support-guide.html) to verify that those changes are supported by your Pega Platform version.
 
 5. Create namespaces for your Pega deployment, backingservices and the addons (if applicable for your environment).
 
@@ -101,7 +101,7 @@ $ helm install backingservices pega/backingservices --namespace pegabackingservi
 $ helm install addons pega/addons --namespace pegaaddons --values addons.yaml
 ```
 
-8. With addons and backservices deployed, you are ready to deploy Pega Infinity using the pega chart. Before installing using the chart, it is a good idea to review the detailed [deployment guide](https://community.pega.com/knowledgebase/articles/deploying-pega-platform-using-kubernetes) to understand how Pega deploys as a distributed system. Running a Helm installation using the pega chart installs a Pega Infinity instance into a specified namespace. After you edit the chart with your configuration requirements, run the following command to install the pega chart. 
+8. With addons and backservices deployed, you are ready to deploy Pega Infinity using the pega chart. Before installing using the chart, it is a good idea to review [Containerized deployments in Kubernetes environments](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/containerized-deployments-kubernetes.html) to understand how Pega deploys as a distributed system. Running a Helm installation using the pega chart installs a Pega Infinity instance into a specified namespace. After you edit the chart with your configuration requirements, run the following command to install the pega chart. 
 
 ```bash
 $ helm install mypega pega/pega --namespace mypega --values pega.yaml
@@ -131,7 +131,7 @@ To upgrade your strategic application, use the latest Upgrade Guide available fo
 
 ## Patches
 
-To apply a Pega Platform patch with zero downtime to your existing Pega platform software, you must download the latest installer Docker images from Pega Digital Software Delivery and change several options in your Pega Helm chart. For details and helpful resources explaining the Pega Platform patch process, including the Pega Infinity patch policy, see [Applying the latest patch](https://community.pega.com/knowledgebase/articles/keeping-current-pega/86/applying-latest-patch). For step-by-step guidance to apply a Pega Platform patch, see the Pega-provided runbook, [Patching Pega Platform in your deployment](/docs/patching-pega-deployment.md).
+To apply a Pega Platform patch with zero downtime to your existing Pega platform software, you must download the latest installer Docker images from Pega Digital Software Delivery and change several options in your Pega Helm chart. For details and helpful resources explaining the Pega Platform patch process, including the Pega Infinity patch policy, see [Pega software maintenance program](https://docs.pega.com/bundle/keeping-current/page/keeping-current/kc/pega-software-maintenance.html). For step-by-step guidance to apply a Pega Platform patch, see the Pega-provided runbook, [Patching Pega Platform in your deployment](/docs/patching-pega-deployment.md).
 
 # Downloading Docker images for your deployment
 
@@ -148,7 +148,7 @@ Status: Downloaded pega-docker.downloads.pega.com/platform/pega:<version>
 
 All Docker images for Pega Platform releases that are in Standard Support undergo a nightly rebuild that applies the latest available updates and patches to all third-party components. To take advantage of these updates, you must redeploy your Pega Platform with the latest available images. Pega does not guarantee nightly rebuilds for Pega Platform releases in Extended Support and stops rebuilding images for Pega Platform releases that are out of Extended Support.
 
-For details about downloading and then pushing Docker images to your repository for your deployment, see [Using Pega-provided Docker images](https://docs.pega.com/bundle/platform-88/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html).
+For details about downloading and then pushing Docker images to your repository for your deployment, see [Using Pega-provided Docker images](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html).
 
 From Helm chart versions `2.2.0` and above, update your Pega Platform version to the latest patch version.
 
@@ -196,7 +196,7 @@ New versions of this Helm Chart may be released at any time. Versions are define
 
 ## Helm charts and Docker images compatibility
 
-Both Helm charts and Docker images undergo frequent updates; new Helm chart releases may appear at any time, and the latest patch versions of the Docker images are rebuilt nightly as part of software maintenance (for more information, see [Pega-provided Docker images](https://docs.pega.com/bundle/platform-88/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html)). This might result in incompatibility issues during the install and upgrade process. To ensure that Helm charts and Docker images are compatible, do one of the following actions:
+Both Helm charts and Docker images undergo frequent updates; new Helm chart releases may appear at any time, and the latest patch versions of the Docker images are rebuilt nightly as part of software maintenance (for more information, see [Pega-provided Docker images](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html)). This might result in incompatibility issues during the install and upgrade process. To ensure that Helm charts and Docker images are compatible, do one of the following actions:
 
 * If you update your Helm charts to the latest version to take advantage of new features, update your Docker images to the latest version as well (latest build of the latest patch).
 * If you upgrade your Pega Platform to a later version, use the latest Docker image build and latest Helm chart version.

--- a/charts/backingservices/charts/constellation-messaging/README.md
+++ b/charts/backingservices/charts/constellation-messaging/README.md
@@ -6,7 +6,7 @@ Once the service routing (with TLS) is set up, configure the Pega Infinity Const
 
 Only a single Messaging Service deployment is necessary to support an entire organization.  Do not install the service in every namespace or for every application or project.
 
-Complete information on the design of the service including architecture, scalability, reliability, operations and troubleshooting is available at [https://documents.constellation.pega.io/messaging/introduction.html](https://documents.constellation.pega.io/messaging/introduction.html).
+Complete information on the design of the service including architecture, scalability, reliability, operations and troubleshooting is available at [Constellation service deployment](https://docs.pega.com/bundle/platform/page/platform/deployment/constellation/constellation-overview.html).
 
 ## Configuration settings
 

--- a/charts/backingservices/charts/constellation/README.md
+++ b/charts/backingservices/charts/constellation/README.md
@@ -1,9 +1,6 @@
 # Constellation UI setup
 
-Please refer to 
- > https://documents.constellation.pega.io/static/88/introduction.html
-
-for instructions related to the pegastatic content delivery setup. Once that is complete please proceed with the instructions below for the constellation appstatic service setup.
+Please refer to [Constellation service deployment](https://docs.pega.com/bundle/platform/page/platform/deployment/constellation/constellation-overview.html) for instructions related to the pegastatic content delivery setup. Once that is complete please proceed with the instructions below for the constellation appstatic service setup.
 
 ## ConstellationUI helm chart
 
@@ -30,7 +27,7 @@ Digest: <encryption verification>
 Status: Downloaded pega-docker.downloads.pega.com/constellation-appstatic-service/docker-image:xxxxxxx
 ```
 
-For details about downloading and then pushing Docker images to your repository for your deployment, see [Using Pega-provided Docker images](https://docs.pega.com/client-managed-cloud/87/pega-provided-docker-images).
+For details about downloading and then pushing Docker images to your repository for your deployment, see [Pega-provided Docker images](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html).
 
 
 #### Constellationui runtime configuration

--- a/charts/pega/README.md
+++ b/charts/pega/README.md
@@ -260,7 +260,7 @@ Pega supports deployments using a multi-tier architecture model that separates a
 
 Three values.yaml files are provided to showcase real world deployment examples.  These examples can be used as a starting point for customization and are not expected to deployed as-is.
 
-For more information about the architecture for how Pega Platform runs in a Pega cluster, see [How Pega Platform and applications are deployed on Kubernetes](https://community.pega.com/knowledgebase/articles/cloud-choice/how-pega-platform-and-applications-are-deployed-kubernetes).
+For more information about the architecture for how Pega Platform runs in a Pega cluster, see [Containerized deployments in Kubernetes environments](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/containerized-deployments-kubernetes.html).
 
 #### Standard deployment using two tiers
 
@@ -302,11 +302,9 @@ name: "mycrm-prod-web"
 ### nodeType (*Required*)
 
 Node classification is the process of separating nodes by purpose, predefining their behavior by assigning node types. When you associate a work resource with a specific node type,you optimize work performance in your Pega application. For more information, see
-[Node classification](https://community.pega.com/sites/default/files/help_v83/procomhelpmain.htm#engine/node-classification/eng-node-classification-con.htm).
+[Classifying nodes](https://docs.pega.com/bundle/platform/page/platform/system-administration/node-classifying-overview.html).
 
-Specify the list of Pega node types for this deployment.  For more information about valid node types, see the Pega Community article on [Node Classification].
-
-[Node types for VM-based and containerized deployments](https://docs.pega.com/bundle/platform-88/page/platform/system-administration/node-types-on-premises.html)
+Specify the list of Pega node types for this deployment.  For more information about valid node types, see [Node types for VM-based and containerized deployments](https://docs.pega.com/bundle/platform/page/platform/system-administration/node-types-on-premises.html)
 
 Example:
 
@@ -944,7 +942,7 @@ Use the `pegasearch` section to configure the source Elasticsearch service that 
 
 Use the chart ['backingservices'](../backingservices) to deploy the Search and Reporting Service (SRS), a Pega Platform backing service enabling the latest generation of search and reporting capabilities for your Pega applications. SRS is independent from Pega Platform and replaces the previous implementation of Elasticsearch, the legacy client-server Elasticsearch plug-in.
 
-To use SRS, follow the deployment instructions provided at ['backingservices'](../backingservices) before you configure and deploy the Pega Helm chart. For more information, see [External Elasticsearch in your deployment](https://docs.pega.com/bundle/platform-88/page/platform/deployment/externalization-of-services/externalize-search-in-your-deployment.html).
+To use SRS, follow the deployment instructions provided at ['backingservices'](../backingservices) before you configure and deploy the Pega Helm chart. For more information, see [External Elasticsearch in your deployment](https://docs.pega.com/bundle/platform/page/platform/deployment/externalization-of-services/externalize-search-in-your-deployment.html).
 
 Configure the customerDeploymentId parameter in the global section of the values.yaml to provide data isolation in SRS.  The customerDeploymentId is used as a prefix for all indexes created in ElasticSearch, and must be the value of the 'guid' claim if OAuth is used for authorization between Pega and SRS.  This parameter defaults to the name of the namespace when left empty.
 
@@ -998,7 +996,7 @@ Use the following configuration to provision the legacy client-server Elasticsea
 
 Parameter   | Description   | Default value
 ---         | ---           | ---
-`image`   | Set the `pegasearch.image` parameter to a registry that can access the Pega-provided `platform/search` Docker image. Download the image from the Pega repository, tag it, and push it to your local registry. As a best practice, use the latest available image for your Pega Platform version, based on the build date specified in the tag. For example, the image tagged "8.5.6-20230829" was built on August 29, 2023. For more information, see [Pega-provided Docker images](https://docs.pega.com/bundle/platform-88/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html).| `platform/search:8.5.x-XXXXXXXX`
+`image`   | Set the `pegasearch.image` parameter to a registry that can access the Pega-provided `platform/search` Docker image. Download the image from the Pega repository, tag it, and push it to your local registry. As a best practice, use the latest available image for your Pega Platform version, based on the build date specified in the tag. For example, the image tagged "8.5.6-20230829" was built on August 29, 2023. For more information, see [Pega-provided Docker images](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html).| `platform/search:8.5.x-XXXXXXXX`
 `imagePullPolicy` | Optionally specify an imagePullPolicy for the search container. | `""`
 `replicas` | Specify the desired replica count. | `1`
 `minimumMasterNodes` | To prevent data loss, you must configure the minimumMasterNodes setting so that each master-eligible node is set to the minimum number of master-eligible nodes that must be visible in order to form a cluster. Configure this value using the formula (n/2) + 1 where n is replica count or desired capacity.  For more information, see the Elasticsearch [important setting documentation](https://www.elastic.co/guide/en/elasticsearch/reference/current/important-settings.html) for more information. | `1`
@@ -1073,7 +1071,7 @@ stream:
 
 ## Pega database installation and upgrades
 
-Pega requires a relational database that stores the rules, data, and work objects used and generated by Pega Platform. The [Pega Platform deployment guide](https://community.pega.com/knowledgebase/products/platform/deploy) provides detailed information about the requirements and instructions for installations and upgrades.  Follow the instructions for Tomcat and your environment's database server.
+Pega requires a relational database that stores the rules, data, and work objects used and generated by Pega Platform. For more detailed information about the requirements and instructions for installations and upgrades, see [Containerized deployments in Kubernetes environments](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/containerized-deployments-kubernetes.html).  Follow the instructions for Tomcat and your environment's database server.
 
 The Helm charts also support an automated install or upgrade with a Kubernetes Job.  The Job utilizes an installation Docker image and can be activated with the `action` parameter in the Pega Helm chart.
  
@@ -1097,11 +1095,11 @@ installer:
 
 The Pega Helm charts support zero-downtime patch and upgrades processes which synchronize the required process steps to minimize downtime. With these zero-downtime processes, you and your customers can continue to access and use their applications in your environment with minimal disruption while you patch or upgrade your system.
 
-To **upgrade Pega Platform software** deployed in a Kubernetes environment in zero-downtime, you must download the latest Pega-provided images for the version to which you are upgrading from  [Pega Digital Software Delivery](https://community.pega.com/digital-delivery) and use the Helm chart with versions 1.6.0 or later to complete the upgrade. To learn about how the upgrade process works and its requirements and the steps you must complete, see the Pega-provided runbook, [Upgrading Pega Platform in your deployment with zero-downtime](/docs/upgrading-pega-deployment-zero-downtime.md). With earlier versions of the Pega Helm charts, you must use the Pega Platform upgrade guides. To obtain the latest upgrade guide, see [Stay current with Pega](https://community.pega.com/upgrade).
-
+To **upgrade Pega Platform software** deployed in a Kubernetes environment in zero-downtime, you must download the latest Pega-provided images for the version to which you are upgrading from  [Pega Digital Software Delivery](https://community.pega.com/digital-delivery) and use the Helm chart with versions 1.6.0 or later to complete the upgrade. To learn about how the upgrade process works and its requirements and the steps you must complete, see the Pega-provided runbook, [Upgrading Pega Platform in your deployment with zero-downtime](/docs/upgrading-pega-deployment-zero-downtime.md). 
+ 
 To complete your Pega Infinity upgrade, after you upgrade your Pega Platform software using the Pega Helm charts and Docker images, you must use the latest Pega application software Upgrade Guide, which is separate from Pega Platform software. You can locate the appropriate upgrade guide for your installed application from the page, [All Products](https://community.pega.com/knowledgebase/products).
 
-To **apply a Pega Platform patch** with zero-downtime to your existing Pega platform software, you use the same "zero-downtime" parameters that you use for upgrades and use the Pega-provided `platform/installer` Docker image that you downloaded for your patch version. For step-by-step guidance to apply a Pega Platform patch, see the Pega-provided runbook, [Patching Pega Platform in your deployment](/docs/patching-pega-deployment.md). The patch process applies only changes observed between the patch and your currently running version and then separately upgrades the data. For details about Pega patches, see [Pega software maintenance and extended support policy](https://community.pega.com/knowledgebase/articles/keeping-current-pega/85/pega-software-maintenance-and-extended-support-policy).
+To **apply a Pega Platform patch** with zero-downtime to your existing Pega platform software, you use the same "zero-downtime" parameters that you use for upgrades and use the Pega-provided `platform/installer` Docker image that you downloaded for your patch version. For step-by-step guidance to apply a Pega Platform patch, see the Pega-provided runbook, [Patching Pega Platform in your deployment](/docs/patching-pega-deployment.md). The patch process applies only changes observed between the patch and your currently running version and then separately upgrades the data. For details about Pega patches, see [Pega software maintenance program](https://docs.pega.com/bundle/keeping-current/page/keeping-current/kc/pega-software-maintenance.html).
 
 Use the `installer` section  of the values file with the appropriate parameters to install, upgrade, or apply a patch to your Pega Platform software:
 

--- a/docs/Deploying-Pega-on-AKS.md
+++ b/docs/Deploying-Pega-on-AKS.md
@@ -23,7 +23,7 @@ Use Kubernetes tools and the customized orchestration tools and Docker images to
 
 4. Configure your network connections in the DNS management zone of your choice so you can log in to Pega Platform - [Logging in to Pega Platform – 10 minutes](#logging-in-to-pega-platform--10-minutes).
 
-To understand how Pega maps Kubernetes objects with Pega applications and services, see [Understanding the Pega deployment architecture](https://community.pega.com/knowledgebase/articles/client-managed-cloud/cloud/understanding-pega-deployment-architecture).
+To understand how Pega maps Kubernetes objects with Pega applications and services, see [Understanding the Pega deployment architecture](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-kubernetes-architecture.html).
 
 ## Assumptions and prerequisites
 

--- a/docs/Deploying-Pega-on-EKS.md
+++ b/docs/Deploying-Pega-on-EKS.md
@@ -29,7 +29,7 @@ Use Kubernetes tools and the customized orchestration tools and Docker images to
 
 4. Configure your network connections in the DNS management zone of your choice so you can log in to Pega Platform - [Logging in to Pega Platform – 10 minutes](#logging-in-to-pega-platform--10-minutes).
 
-To understand how Pega maps Kubernetes objects with Pega applications and services, see [Understanding the Pega deployment architecture](https://community.pega.com/knowledgebase/articles/client-managed-cloud/cloud/understanding-pega-deployment-architecture).
+To understand how Pega maps Kubernetes objects with Pega applications and services, see [Understanding the Pega deployment architecture](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-kubernetes-architecture.html).
 
 ## Assumptions and prerequisites
 

--- a/docs/Deploying-Pega-on-GKE.md
+++ b/docs/Deploying-Pega-on-GKE.md
@@ -18,7 +18,7 @@ Use Kubernetes tools and the customized orchestration tools and Docker images to
 
 4. Configure your network connections in the DNS management zone of your choice so you can log in to Pega Platform - [Logging in to Pega Platform – 10 minutes](#logging-in-to-pega-platform--10-minutes).
 
-To understand how Pega maps Kubernetes objects with Pega applications and services, see [Understanding the Pega deployment architecture](https://community.pega.com/knowledgebase/articles/client-managed-cloud/cloud/understanding-pega-deployment-architecture).
+To understand how Pega maps Kubernetes objects with Pega applications and services, see [Understanding the Pega deployment architecture](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-kubernetes-architecture.html).
 
 ## Assumptions and prerequisites
 

--- a/docs/Deploying-Pega-on-PKS.md
+++ b/docs/Deploying-Pega-on-PKS.md
@@ -25,7 +25,7 @@ Use Kubernetes tools and the customized orchestration tools and Docker images to
 
 4. Configure your network connections in the DNS management zone of your choice so you can log in to Pega Platform - [Logging in to Pega Platform – 10 minutes](#logging-in-to-pega-platform--10-minutes).
 
-To understand how Pega maps Kubernetes objects with Pega applications and services, see [Understanding the Pega deployment architecture](https://community.pega.com/knowledgebase/articles/client-managed-cloud/cloud/understanding-pega-deployment-architecture).
+To understand how Pega maps Kubernetes objects with Pega applications and services, see [Understanding the Pega deployment architecture](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-kubernetes-architecture.html).
 
 ## Assumptions and prerequisites
 

--- a/docs/Deploying-Pega-on-openshift.md
+++ b/docs/Deploying-Pega-on-openshift.md
@@ -27,7 +27,7 @@ Use Kubernetes tools and the customized orchestration tools and Docker images to
 
 4. Configure your network connections in the DNS management zone of your choice so you can log in to Pega Platform - [Logging in to Pega Platform – 10 minutes](#logging-in-to-pega-platform--10-minutes).
 
-To understand how Pega maps Kubernetes objects with Pega applications and services, see [Understanding the Pega deployment architecture](https://community.pega.com/knowledgebase/articles/client-managed-cloud/cloud/understanding-pega-deployment-architecture).
+To understand how Pega maps Kubernetes objects with Pega applications and services, see [Understanding the Pega deployment architecture](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-kubernetes-architecture.html).
 
 ## Assumptions and prerequisites
 

--- a/docs/building-your-own-Pega-installer-image.md
+++ b/docs/building-your-own-Pega-installer-image.md
@@ -3,18 +3,17 @@ Building a Pega Platform installer docker image
 
 These instructions require the Pega Platform distribution image to install the Pega Platform onto your database.
 
-Clients with appropriate licenses can download a distribution image from Pega. For additional instructions, see [Pega Digital Software Delivery User Guide](https://community.pega.com/knowledgebase/documents/pega-digital-software-delivery-user-guide).
+Clients with appropriate licenses can download a distribution image from Pega. For additional instructions, see [Pega-provided Docker images](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html).
 
 ## Downloading a Pega Platform distribution to your local system
 
-These instructions require the Pega Platform distribution image to install the Pega Platform onto your database. To obtain a copy, you must download an image from Pega. For detailed instructions, see [Pega Digital Software Delivery User Guide](https://community.pega.com/knowledgebase/documents/pega-digital-software-delivery-user-guide).
+These instructions require the Pega Platform distribution image to install the Pega Platform onto your database. To obtain a copy, you must download an image from Pega. For detailed instructions, see [Pega-provided Docker images](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html).
 
 ### Requesting access to a Pega Platform distribution
 
 1. In the browser of your choice, navigate to the Pega [Digital Software Delivery](https://community.pega.com/digital-delivery) site.
 
-2. Log into the [Pega Community](https://community.pega.com/knowledgebase/articles/pega-cloud/pega-cloud-services-patch-process-releases-83x-and-later)
-    site with the credentials your Pega representative provided.
+2. Log into the site with the credentials your Pega representative provided.
 
 3. In the **Download and Upgrade Licensed Software** area, click **New
     request**.

--- a/docs/patching-pega-deployment.md
+++ b/docs/patching-pega-deployment.md
@@ -4,15 +4,16 @@ After you deploy Pega Platform™ on your kubernetes environment, the Pega-prov
 
 Useful links to Pega software patching information:
 
-- [Pega software maintenance and extended support policy](https://community.pega.com/knowledgebase/articles/keeping-current-pega/85/pega-software-maintenance-and-extended-support-policy)
+- [Pega software maintenance program](https://docs.pega.com/bundle/keeping-current/page/keeping-current/kc/pega-software-maintenance.html)
+- [Pega Extended Support program](https://docs.pega.com/bundle/keeping-current/page/keeping-current/kc/extended-support-policy.html)
 - [Pega Infinity patch calendar](https://community.pega.com/knowledgebase/articles/keeping-current-pega/pega-infinity-patch-calendar)
-- [Pega Infinity patch frequently asked questions](https://community.pega.com/knowledgebase/articles/keeping-current-pega/85/pega-infinity-patch-frequently-asked-questions)
+- [Pega software maintenance policies frequently asked questions](https://docs.pega.com/bundle/keeping-current/page/keeping-current/kc/pega-software-maintenance-faqs.html)
 
 ## Kubernetes-based patching process overview
 
-Pega supports client-managed cloud clients applying patches for releases 8.4 and later using a zero-downtime patch process to apply the latest cumulative bundle of bug and security fixes since the last minor release. For the latest Pega Community articles, see [About client managed cloud](https://community.pega.com/knowledgebase/articles/client-managed-cloud/85/about-client-managed-cloud).
+Pega supports client-managed cloud clients applying patches for releases 8.4 and later using a zero-downtime patch process to apply the latest cumulative bundle of bug and security fixes since the last minor release. For more information, see [Containerized deployments in Kubernetes environments](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/containerized-deployments-kubernetes.html).
 
-The Pega zero-downtime patch process uses the zero-downtime patch process so you and your customers can continue working in your application while you patch your system. Pega zero-downtime patch scripts use a temporary data schema and the patch migration script moves the rules between the appropriate schema and then performs the required rolling reboot of your deployment cluster. For a detailed overview of the process, see [Applying a patch without downtime](https://community.pega.com/knowledgebase/articles/keeping-current-pega/86/applying-patch-without-downtime).
+The Pega zero-downtime patch process uses the zero-downtime patch process so you and your customers can continue working in your application while you patch your system. Pega zero-downtime patch scripts use a temporary data schema and the patch migration script moves the rules between the appropriate schema and then performs the required rolling reboot of your deployment cluster.
 
 ## Client-required steps
 Client-managed cloud clients use the same Pega Kubernetes tools and Helm charts in the same Pega repository that you used to install Pega Platform in a supported Kubernetes environment. The client-managed cloud patch process includes the following tasks:

--- a/docs/upgrading-pega-deployment-zero-downtime.md
+++ b/docs/upgrading-pega-deployment-zero-downtime.md
@@ -2,7 +2,7 @@
 
 After you deploy Pega Platform™ on your kubernetes environment, you can use a Pega-provided Docker image-based process to upgrade your Pega software with zero-downtime. The following procedures are written for any level of user, from a system administrator to a development engineer who wants to use helm charts and Pega Docker images to upgrade the Pega software you have deployed in any supported kubernetes environment.
 
-For the latest Pega Community articles about Pega-provided docker images, see [About client managed cloud](https://community.pega.com/knowledgebase/articles/client-managed-cloud/86/about-client-managed-cloud).
+For more information, see [Pega-provided Docker images](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html).
 
 ## Kubernetes-based zero-downtime upgrade process overview
 


### PR DESCRIPTION
Many links to Pega Community forward the user to the docs-previous page that is being decommissioned.