### PR TITLE
Remove recommendation for ExitOnOutOfMemoryError as it causes problem…

### DIFF
--- a/charts/pega/RecommendedJVMArgs.md
+++ b/charts/pega/RecommendedJVMArgs.md
@@ -44,12 +44,6 @@ This is the Java8+ equivalent of *PermGen* space. This space is unbounded by def
 **Pega Recommendation**: Set to use *dev/urandom* <br>
 **Note**: *This JVM argument is hardcoded in the Docker image with the recommended value. You cannot explicitly overwrite this argument.*
 
-**Flag**: `-XX:+ExitOnOutOfMemoryError` <br>
-**Purpose**: Exits the JVM when an OutOfMemoryError occurs. Exiting is required, as allowing the JVM to run after OutOfMemoryError leads to inconsistent system state.<br>
-**JVM default**: *ExitOnOutOfMemoryError=false* equivalent to `-XX:-ExitOnOutOfMemoryError`<br>
-**Pega Recommendation**: Set to Exit the JVM in case of OutOfMemoryError <br>
-**Note**: *This JVM argument is hardcoded in the Docker image with the recommended value. You cannot explicitly overwrite this argument.*
-
 **Flag**: `-Xlog:gc*,gc+heap=debug,gc+humongous=debug:file=/usr/local/tomcat/logs/gc.log:uptime,pid,level,time,tags:filecount=3,filesize=2M` <br>
 **Purpose**: Dumps the GC logs with the provided tags into local log file. <br>
 **JVM default**: No GC logs will be emitted by default.<br>


### PR DESCRIPTION
…s when trying to capture heap dumps.