### PR TITLE
[BUG-920600] Build custom Pega images

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ All Docker images for Pega Platform releases that are in Standard Support underg
 
 For details about downloading and then pushing Docker images to your repository for your deployment, see [Using Pega-provided Docker images](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html).
 
+For details about customizing your Pega-provided Docker images, see [Build your own custom Pega images](https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html#ariaid-title5).
+
 From Helm chart versions `2.2.0` and above, update your Pega Platform version to the latest patch version.
 
 # Debugging failed upgrades using helm commands

--- a/charts/backingservices/charts/srs/README.md
+++ b/charts/backingservices/charts/srs/README.md
@@ -39,7 +39,7 @@ The service deployment provisions runtime service pods along with a dependency o
         </tr>
         <tr>
             <td rowspan=5> >= 8.6 </td>
-            <td rowspan=5>1.37.9</td>
+            <td rowspan=5>1.37.3</td>
             <td rowspan=4> <b>search-n-reporting-service</b></td>
             <td rowspan=2>< 1.25</td>
             <td>Not enabled</td>

--- a/charts/backingservices/charts/srs/README.md
+++ b/charts/backingservices/charts/srs/README.md
@@ -39,7 +39,7 @@ The service deployment provisions runtime service pods along with a dependency o
         </tr>
         <tr>
             <td rowspan=5> >= 8.6 </td>
-            <td rowspan=5>1.37.3</td>
+            <td rowspan=5>1.37.9</td>
             <td rowspan=4> <b>search-n-reporting-service</b></td>
             <td rowspan=2>< 1.25</td>
             <td>Not enabled</td>


### PR DESCRIPTION
Added link to https://docs.pega.com/bundle/platform/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html#ariaid-title5 as requested.

From: Peterson, John <John.Peterson@pega.com> 
Sent: Tuesday, April 8, 2025 1:37 PM
To: Kowalska, Kinga <Kinga.Kowalska@pega.com>
Subject: Build custom Pega images

Hi Kinga,

I have some feedback on this documentation:  https://docs.pega.com/bundle/platform-88/page/platform/deployment/client-managed-cloud/pega-docker-images-manage.html#ariaid-title5

1)	The section title should be renamed to “Build your own custom Pega images” since it describes how to do it for the Installer, Runtime, and Search images, and not just the installer.
2)	“Your organization must may enforce a corporate standard as to the operating system and Java libraries to include in your Docker images.”   Also, the purpose of this sentence is to explain the motivation for building custom images, it might help to make it more clear by saying that “You should consider building your own custom Pega images if your org enforces”
3)	Since we’re still in the parent section that applies to all images, remove mention of the installer explicitly.   “If you build your own installation images, you should be familiar with Docker commands to build your own images. As a starting point, see Dockerfile reference.”
4)	Also, this Custom Pega section should be linked to from the Pega Helm Charts main page on Github.  Probably as part of this section:  https://github.com/pegasystems/pega-helm-charts?tab=readme-ov-file#downloading-docker-images-for-your-deployment or nearby.

Thanks,
John