### PR TITLE
Do not render secrets if external secret is provided

### DIFF
--- a/charts/pega/charts/hazelcast/templates/_supplemental.tpl
+++ b/charts/pega/charts/hazelcast/templates/_supplemental.tpl
@@ -51,7 +51,7 @@ false
 {{- end }}
 
 {{- define "imagePullSecrets" }}
-{{- if .Values.global.docker.registry }}
+{{- if and .Values.global.docker.registry (not .Values.global.docker.imagePullSecretNames) }}
 - name: {{ template "pegaRegistrySecret" $ }}
 {{- end }}
 {{- if (.Values.global.docker.imagePullSecretNames) }}

--- a/charts/pega/charts/installer/templates/_supplemental.tpl
+++ b/charts/pega/charts/installer/templates/_supplemental.tpl
@@ -51,7 +51,7 @@ false
 {{- end }}
 
 {{- define "imagePullSecrets" }}
-{{- if .Values.global.docker.registry }}
+{{- if and .Values.global.docker.registry (not .Values.global.docker.imagePullSecretNames) }}
 - name: {{ template "pegaRegistrySecret" $ }}
 {{- end }}
 {{- if (.Values.global.docker.imagePullSecretNames) }}

--- a/charts/pega/charts/pegasearch/templates/_supplemental.tpl
+++ b/charts/pega/charts/pegasearch/templates/_supplemental.tpl
@@ -51,7 +51,7 @@ false
 {{- end }}
 
 {{- define "imagePullSecrets" }}
-{{- if .Values.global.docker.registry }}
+{{- if and .Values.global.docker.registry (not .Values.global.docker.imagePullSecretNames) }}
 - name: {{ template "pegaRegistrySecret" $ }}
 {{- end }}
 {{- if (.Values.global.docker.imagePullSecretNames) }}

--- a/charts/pega/templates/_supplemental.tpl
+++ b/charts/pega/templates/_supplemental.tpl
@@ -51,7 +51,7 @@ false
 {{- end }}
 
 {{- define "imagePullSecrets" }}
-{{- if .Values.global.docker.registry }}
+{{- if and .Values.global.docker.registry (not .Values.global.docker.imagePullSecretNames) }}
 - name: {{ template "pegaRegistrySecret" $ }}
 {{- end }}
 {{- if (.Values.global.docker.imagePullSecretNames) }}

--- a/charts/pega/templates/pega-registry-secret.yaml
+++ b/charts/pega/templates/pega-registry-secret.yaml
@@ -1,3 +1,3 @@
-{{- if .Values.global.docker.registry }}
+{{- if and .Values.global.docker.registry (not .Values.global.docker.imagePullSecretNames) }}
 {{- include "pegaRegistryCredentialsSecretTemplate" . }}
 {{- end }}

--- a/charts/pega/templates/pega-tomcat-keystore-secret.yaml
+++ b/charts/pega/templates/pega-tomcat-keystore-secret.yaml
@@ -3,7 +3,7 @@
 {{ if (eq (include "performDeployment" $) "true") }}
 {{ range $index, $dep := .Values.global.tier }}
 {{ if (($dep.service).tls).enabled }}
-{{ if not (($dep.service).tls).external_secret_name }}
+{{ if not (($dep.service).tls).external_secret_names }}
 {{ $data := dict "root" $ "node" $dep "name" $depName }}
 {{- include "pegaTomcatKeystoreSecretTemplate" $data }}
 {{ end }}

--- a/terratest/src/test/pega/pega-deployment-with-and-without-image-pull-secrets_test.go
+++ b/terratest/src/test/pega/pega-deployment-with-and-without-image-pull-secrets_test.go
@@ -278,10 +278,9 @@ func assertWithImagePullSecrets(t *testing.T, webYaml string) {
 	var deploymentObj appsv1.Deployment
 	UnmarshalK8SYaml(t, webYaml, &deploymentObj)
 	imagePullSecrets := deploymentObj.Spec.Template.Spec.ImagePullSecrets
-	require.Equal(t, imagePullSecrets[0].Name, "pega-registry-secret")
-	require.Equal(t, imagePullSecrets[1].Name, "secret1")
-	require.Equal(t, imagePullSecrets[2].Name, "secret2")
-	require.Equal(t, len(imagePullSecrets), 3)
+	require.Equal(t, imagePullSecrets[0].Name, "secret1")
+	require.Equal(t, imagePullSecrets[1].Name, "secret2")
+	require.Equal(t, len(imagePullSecrets), 2)
 }
 
 func assertWithoutRegistryBlock(t *testing.T, webYaml string) {


### PR DESCRIPTION
Fixes issue #812 

1) When service.tls.external_secret_names is not empty, pega-tomcat-keystore-secret.yaml isn't rendered.  Currently this secret is always rendered with default values.  When more than one tier has an ingress defined, this secret contains duplicate keys which is allowed by helm but not allowed by kustomize.  This change allows us to use kustomize with two tiers that have an ingress.

2) When docker.imagePullSecretNames is not empty pega-registry-secret.yaml isn't rendered.  Currently this secret is always rendered with dummy values when using an external secret.
