### PR TITLE
BUG-926651 - SRS documentation changes 

### DIFF
--- a/charts/backingservices/charts/srs/README.md
+++ b/charts/backingservices/charts/srs/README.md
@@ -39,7 +39,7 @@ The service deployment provisions runtime service pods along with a dependency o
         </tr>
         <tr>
             <td rowspan=5> >= 8.6 </td>
-            <td rowspan=5>1.37.9</td>
+            <td rowspan=5>1.38.2</td>
             <td rowspan=4> <b>search-n-reporting-service</b></td>
             <td rowspan=2>< 1.25</td>
             <td>Not enabled</td>
@@ -72,6 +72,7 @@ The service deployment provisions runtime service pods along with a dependency o
     </tbody>
 </table>
 
+**Important:** Pega supports only official Elasticsearch and OpenSearch Docker images. Custom images, for example, `bitnami/elasticsearch`, are not supported.
 
 **Note:**
 

--- a/charts/backingservices/values.yaml
+++ b/charts/backingservices/values.yaml
@@ -107,7 +107,7 @@ srs:
     # and add the parameter details: srs.srsStorage.awsIAM and its associated region, srs.srsStorage.awsIAM.region
     # awsIAM:
     #   region: "AWS_ELASTICSEARCH_REGION"/"AWS_OPENSEARCH_REGION"
-    # Set srs.srsStorage.networkPolicy.enabled: true to enable network policy for the SRS service
+    # Set srs.srsStorage.networkPolicy.enabled: false to disable network policy for the SRS service. The default value is true.
     networkPolicy:
       enabled: true
     # To configure either authentication method, when the Elasticsearch/OpenSearch domain requires an open internet connection,


### PR DESCRIPTION
Made documentation changes following the request below:

From: Meka, Ravi Teja <RaviTeja.Meka@in.pega.com> 
Sent: Monday, May 12, 2025 9:25 AM
To: Kowalska, Kinga <Kinga.Kowalska@pega.com>
Cc: SearchX <SearchX@pega.com>
Subject: SRS Version update: 1.38.2

Hi [@Kowalska, Kinga](mailto:Kinga.Kowalska@pega.com),

We released new SRS version: 1.38.2 with latest vulnerabilities fixed. Kindly update the documentation.

In addition to above, I have below suggestions for documentation update based on the EA requests we received this sprint:

1.	We need to update documentation, that Pega supports only official docker images of Elasticsearch and OpenSearch, custom images like [bitnami/elasticsearch](https://github.com/bitnami/containers/blob/main/bitnami/elasticsearch/README.md) are not officially supported.

2.	Change [this line:](https://github.com/pegasystems/pega-helm-charts/blob/master/charts/backingservices/values.yaml#L110C1-L111C1) to “Set srs.srsStorage.networkPolicy.enabled: false to disable network policy for the SRS service. Defaults to true”.

Thanks,
Ravi Teja Meka