### PR TITLE
BUG-909894: prpcUtils default heap may be too low

### DIFF
--- a/charts/pega/charts/installer/config/prpcUtils.properties.tmpl
+++ b/charts/pega/charts/installer/config/prpcUtils.properties.tmpl
@@ -28,7 +28,7 @@ user.temp.dir=/opt/pega/temp
 
 # CUSTOM JVM ARGS
 # Use this parameter to add jvm arguments other than Max Heap Size so your deployment nodes invoke these arguments each time the nodes start
-custom.jvm.args=-Xmx4g {{ .Env.CUSTOM_JVM_ARGS }}
+custom.jvm.args=-Xmx8g {{ .Env.CUSTOM_JVM_ARGS }}
 
 ############################### SETTINGS FOR CHANGING DYNAMIC SYSTEM SETTINGS ########
 ######################################################################################


### PR DESCRIPTION
CRM requires a higher heap, updated from previous minimum of 4gb to 8gb