### PR TITLE
Fix logic for finding tier name with "WebUser" node type

### DIFF
--- a/charts/pega/charts/installer/templates/_helpers.tpl
+++ b/charts/pega/charts/installer/templates/_helpers.tpl
@@ -223,7 +223,7 @@ currentFunctionPath=SYSIBM,SYSFUN,{{ include "resolvedDataSchema" . | upper }}
 {{- $webAppContextPath := "prweb" }}
 {{- range $index, $tier := .Values.global.tier }}
   {{- if hasKey $tier "nodeType" }}
-    {{- if and (contains $tier.nodeType "WebUser") (hasKey $tier "service") }}
+    {{- if and (contains "WebUser" $tier.nodeType) (hasKey $tier "service") }}
     {{- $webTier = $tier.name }}
     {{- if eq "" $webTierServiceName }}
       {{- $webTierServiceName = printf "%s-%s" $depName $webTier }}


### PR DESCRIPTION
My Pega deployment had a single tier with name "pega", and when upgrading with zero-downtime action, the logic for inferring the Pega REST Server URL has the `contains` function arguments mixed up, so instead of resolving it to `http://pega-pega:80/prweb/PRRestService`, it would turn into `http://pega-web:80/prweb/PRRestService`.

#### Example `pega.yaml`

```yaml
# ...
  tier:
    - name: "pega"
      nodeType: "WebUser,BackgroundProcessing,Search"
      initialHeap: "2048m"
      maxHeap: "2048m"
      replicas: 1
      service:
        httpEnabled: true
        port: 80
        targetPort: 8080
        serviceType: "NodePort"
        tls:
          enabled: true
          port: 443
          targetPort: 8443
          traefik:
            enabled: false
# ...
```

**Expected:** `http://pega-pega:80/prweb/PRRestService`
**Actual:** `http://pega-web:80/prweb/PRRestService`

With this PR it should resolve properly and find `WebUser` inside `nodeType`'s value instead the other way around.