### PR TITLE
Increase installer memory requirements and installer heap size.

### DIFF
--- a/charts/pega/charts/installer/config/setupDatabase.properties.tmpl
+++ b/charts/pega/charts/installer/config/setupDatabase.properties.tmpl
@@ -88,7 +88,7 @@ bypass.load.assembled.classes={{ .Env.BYPASS_LOAD_ASSEMBLED_CLASSES }}
 # Enable adminstrator user after upgrade by default.
 upgrade.enable.admin=true
 
-custom.jvm.args=-Xmx8g {{ .Env.CUSTOM_JVM_ARGS }}
+custom.jvm.args={{ .Env.DEFAULT_MAX_HEAP_SIZE }} {{ .Env.CUSTOM_JVM_ARGS }}
 
 # Enable the automatic resume parameter to support resuming rules_upgrade from point of failure.
 automatic.resume={{ .Env.AUTOMATIC_RESUME_ENABLED }}

--- a/charts/pega/charts/installer/config/setupDatabase.properties.tmpl
+++ b/charts/pega/charts/installer/config/setupDatabase.properties.tmpl
@@ -88,7 +88,7 @@ bypass.load.assembled.classes={{ .Env.BYPASS_LOAD_ASSEMBLED_CLASSES }}
 # Enable adminstrator user after upgrade by default.
 upgrade.enable.admin=true
 
-custom.jvm.args=-Xmx4g {{ .Env.CUSTOM_JVM_ARGS }}
+custom.jvm.args=-Xmx8g {{ .Env.CUSTOM_JVM_ARGS }}
 
 # Enable the automatic resume parameter to support resuming rules_upgrade from point of failure.
 automatic.resume={{ .Env.AUTOMATIC_RESUME_ENABLED }}

--- a/charts/pega/charts/installer/templates/_helpers.tpl
+++ b/charts/pega/charts/installer/templates/_helpers.tpl
@@ -307,3 +307,5 @@ limits:
 {{- .root.Values.image }}
 {{- end }}
 {{- end }}
+
+{{- define "installerDefaultMaxHeapSize" }}-Xmx{{ .Values.installerMaxHeap | default "8g" }}{{- end }}

--- a/charts/pega/charts/installer/templates/_pega-environment-config.tpl
+++ b/charts/pega/charts/installer/templates/_pega-environment-config.tpl
@@ -58,6 +58,7 @@ data:
 {{- if .Values.global.highlySecureCryptoModeEnabled }}
   HIGHLY_SECURE_CRYPTO_MODE_ENABLED: "true"
 {{- end }}
+  DEFAULT_MAX_HEAP_SIZE: {{ include "installerDefaultMaxHeapSize" . }}
 {{- if .Values.advancedSettings }}
   ADVANCED_SETTINGS: |-
 {{- range .Values.advancedSettings }}

--- a/charts/pega/charts/installer/values.yaml
+++ b/charts/pega/charts/installer/values.yaml
@@ -95,11 +95,11 @@ upgrade:
 # Ephemeral storage recommended size is 10G
 resources:
   requests:
-    memory: "5Gi"
+    memory: "12Gi"
     cpu: 1
     # ephemeralStorage: ""
   limits:
-    memory: "6Gi"
+    memory: "12Gi"
     cpu: 2
     # ephemeralStorage: ""
 

--- a/charts/pega/charts/installer/values.yaml
+++ b/charts/pega/charts/installer/values.yaml
@@ -34,6 +34,8 @@ bypassLoadEngineClasses: "false"
 bypassLoadAssembledClasses: "false"
 # Custom JVM arguments for the installer
 customJVMArgs: ""
+# Installer java max heap size -- remember to set in conjuction with installer memory request/limit
+# installerMaxHeap: 8g
 # If 'true', Helm will wait for the install or upgrade to finish, and only succeed if the job completes without error.
 waitForJobCompletion: "false"
 # Optionally specify specific service account

--- a/terratest/src/test/pega/data/expectedSetupdatabase.properties
+++ b/terratest/src/test/pega/data/expectedSetupdatabase.properties
@@ -88,7 +88,7 @@ bypass.load.assembled.classes={{ .Env.BYPASS_LOAD_ASSEMBLED_CLASSES }}
 # Enable adminstrator user after upgrade by default.
 upgrade.enable.admin=true
 
-custom.jvm.args=-Xmx8g {{ .Env.CUSTOM_JVM_ARGS }}
+custom.jvm.args={{ .Env.DEFAULT_MAX_HEAP_SIZE }} {{ .Env.CUSTOM_JVM_ARGS }}
 
 # Enable the automatic resume parameter to support resuming rules_upgrade from point of failure.
 automatic.resume={{ .Env.AUTOMATIC_RESUME_ENABLED }}

--- a/terratest/src/test/pega/data/expectedSetupdatabase.properties
+++ b/terratest/src/test/pega/data/expectedSetupdatabase.properties
@@ -88,7 +88,7 @@ bypass.load.assembled.classes={{ .Env.BYPASS_LOAD_ASSEMBLED_CLASSES }}
 # Enable adminstrator user after upgrade by default.
 upgrade.enable.admin=true
 
-custom.jvm.args=-Xmx4g {{ .Env.CUSTOM_JVM_ARGS }}
+custom.jvm.args=-Xmx8g {{ .Env.CUSTOM_JVM_ARGS }}
 
 # Enable the automatic resume parameter to support resuming rules_upgrade from point of failure.
 automatic.resume={{ .Env.AUTOMATIC_RESUME_ENABLED }}

--- a/terratest/src/test/pega/pega-install-environment-config_test.go
+++ b/terratest/src/test/pega/pega-install-environment-config_test.go
@@ -28,10 +28,10 @@ func TestPegaInstallEnvironmentConfig(t *testing.T) {
 
 			yamlContent := RenderTemplate(t, options, helmChartPath, []string{"charts/installer/templates/pega-install-environment-config.yaml"})
 			assertInstallerEnvironmentConfig(t, yamlContent, options)
+			assertInstallerEnvironmentConfigDefaultInstallerHeap(t, yamlContent, options)
 		}
 	}
 }
-
 
 func TestPegaInstallEnvironmentConfigWithCustomJVMArgs(t *testing.T) {
 
@@ -62,6 +62,46 @@ func assertInstallerEnvironmentConfigWithCustomJVMArgs(t *testing.T, configYaml 
     UnmarshalK8SYaml(t, configYaml, &installEnvConfigMap)
     installEnvConfigData := installEnvConfigMap.Data
     require.Equal(t, installEnvConfigData["CUSTOM_JVM_ARGS"], "-Da=1")
+}
+
+func TestPegaInstallEnvironmentConfigCustomInstallerHeap(t *testing.T) {
+
+	var supportedVendors = []string{"k8s", "openshift", "eks", "gke", "aks", "pks"}
+	var supportedOperations = []string{"install", "install-deploy"}
+
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	for _, vendor := range supportedVendors {
+		for _, operation := range supportedOperations {
+			var options = &helm.Options{
+				SetValues: map[string]string{
+					"global.provider":        vendor,
+					"global.actions.execute": operation,
+					"installer.installerMaxHeap": "10g",
+				},
+			}
+
+			yamlContent := RenderTemplate(t, options, helmChartPath, []string{"charts/installer/templates/pega-install-environment-config.yaml"})
+			assertInstallerEnvironmentConfigCustomInstallerHeap(t, yamlContent, options)
+		}
+	}
+}
+
+func assertInstallerEnvironmentConfigCustomInstallerHeap(t *testing.T, configYaml string, options *helm.Options) {
+	var installEnvConfigMap k8score.ConfigMap
+	UnmarshalK8SYaml(t, configYaml, &installEnvConfigMap)
+	installEnvConfigData := installEnvConfigMap.Data
+
+    require.Equal(t, installEnvConfigData["DEFAULT_MAX_HEAP_SIZE"], "-Xmx10g")
+}
+
+func assertInstallerEnvironmentConfigDefaultInstallerHeap(t *testing.T, configYaml string, options *helm.Options) {
+	var installEnvConfigMap k8score.ConfigMap
+	UnmarshalK8SYaml(t, configYaml, &installEnvConfigMap)
+	installEnvConfigData := installEnvConfigMap.Data
+
+    require.Equal(t, installEnvConfigData["DEFAULT_MAX_HEAP_SIZE"], "-Xmx8g")
 }
 
 func assertInstallerEnvironmentConfig(t *testing.T, configYaml string, options *helm.Options) {

--- a/terratest/src/test/pega/pega-installer-job_test.go
+++ b/terratest/src/test/pega/pega-installer-job_test.go
@@ -231,10 +231,10 @@ func TestPegaInstallerJobWithNonOverriddenImageAndResources(t *testing.T) {
     require.Equal(t, "YOUR_INSTALLER_IMAGE:TAG", jobObj.Spec.Template.Spec.Containers[0].Image)
 
     require.Equal(t, "1", jobObj.Spec.Template.Spec.Containers[0].Resources.Requests.Cpu().String())
-    require.Equal(t, "5Gi", jobObj.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String())
+    require.Equal(t, "12Gi", jobObj.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String())
 
     require.Equal(t, "2", jobObj.Spec.Template.Spec.Containers[0].Resources.Limits.Cpu().String())
-    require.Equal(t, "6Gi", jobObj.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String())
+    require.Equal(t, "12Gi", jobObj.Spec.Template.Spec.Containers[0].Resources.Limits.Memory().String())
 }
 
 func TestPegaInstallerJobWithAffinity(t *testing.T) {

--- a/terratest/src/test/pega/pega-upgrade-environment-config_test.go
+++ b/terratest/src/test/pega/pega-upgrade-environment-config_test.go
@@ -151,6 +151,7 @@ func assertUpgradeEnvironmentConfig(t *testing.T, configYaml string, options *he
 	require.Equal(t, upgradeEnvConfigData["ENABLE_CUSTOM_ARTIFACTORY_SSL_VERIFICATION"], "true")
 	require.Equal(t, upgradeEnvConfigData["AUTOMATIC_RESUME_ENABLED"], "false")
 	require.Equal(t, upgradeEnvConfigData["CUSTOM_JVM_ARGS"], "")
+	require.Equal(t, upgradeEnvConfigData["DEFAULT_MAX_HEAP_SIZE"], "-Xmx8g")
 }
 
 


### PR DESCRIPTION
This PR increases the default memory request/limit for the Pega installer from 5Gi/6Gi to 12Gi/12Gi.

Correspondingly, the maximum java heap for the installer was increased from 4g to 8g.