### PR TITLE
BUG-958744: changed fluentd elasticsearch helm chart repo location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,8 +1,8 @@
 dependencies:
 	helm repo add incubator https://charts.helm.sh/incubator
 	helm repo add stable https://charts.helm.sh/stable
-	helm repo add kiwigrid https://kiwigrid.github.io
 	helm repo add elastic https://helm.elastic.co
+	helm repo add kokuwa https://kokuwaio.github.io/helm-charts
 	helm repo list	
 	helm dependency update ./charts/pega/
 	helm dependency update ./charts/addons/

--- a/charts/addons/requirements.yaml
+++ b/charts/addons/requirements.yaml
@@ -15,8 +15,8 @@ dependencies:
   repository: https://helm.elastic.co/
   condition: elasticsearch.enabled
 - name: fluentd-elasticsearch
-  version: "9.6.0"
-  repository: https://kiwigrid.github.io/
+  version: "15.0.0"
+  repository: https://kokuwaio.github.io/helm-charts
   condition: fluentd-elasticsearch.enabled
 - name: kibana
   version: "7.17.3"


### PR DESCRIPTION
changed fluentd elasticsearch helm chart repo location to kokuwa from kiwigrid