### PR TITLE
US-755005 Review Helm charts docs for Autopilot

### DIFF
--- a/charts/backingservices/charts/autopilot/README.md
+++ b/charts/backingservices/charts/autopilot/README.md
@@ -1,89 +1,96 @@
 # Autopilot Service Helm chart
 
-The Pega `Autopilot Service` backing service provides GenAI-powered capabilities for Pega Infinity Platform by connecting directly to LLM providers (Azure OpenAI, AWS Bedrock, Google Vertex AI). This chart deploys the Autopilot Service for on-premise environments.
+The Pega `Autopilot Service` backing service provides GenAI capabilities for Pega Platform in client-managed cloud and on-premises deployments. This chart deploys the service as an external backing service that connects directly to supported LLM providers without requiring the Pega GenAI Hub gateway. The chart also supports optional OAuth authentication between Pega Platform and the Autopilot Service, a deployment-scoped model list through a bundled or external ConfigMap, and custom OpenAI-compatible providers.
 
-## Pega GenaAI Features Support Matrix
+## Configuring a backing service with your Pega environment
 
-| Pega Version | GenAI Connect | GenAI Coach | GenAI Agent |
+You can deploy the Autopilot Service in the `pega` namespace or in a separate namespace. After deployment, configure the service endpoint in Pega Platform so that the platform can route Autopilot requests to the backing service.
+
+## Pega GenAI feature support matrix
+
+| Pega Platform version | GenAI Connect | GenAI Coach | GenAI Agent |
 |---|:---:|:---:|:---:|
-| 24.2 | Yes | | |
-| 24.2.4 | Yes | Yes | |
-| 25.1.1 *(requires HFIX-C4307)* | Yes | Yes | Yes |
+| 24.2 | Yes | No | No |
+| 24.2.4 | Yes | Yes | No |
+| 25.1.1 (`HFIX-C4307` required) | Yes | Yes | Yes |
 | 25.1.2 | Yes | Yes | Yes |
 
-## Configuring a backing service with your pega environment
-
-You can provision the Autopilot Service into your `pega` environment namespace or any namesapce, with the autopilot service endpoint configured for your Pega Infinity environment.
-
-## Supported LLM Providers
+## Supported LLM providers
 
 | Provider | Authentication Methods |
 |---|---|
-| Azure OpenAI | API Key, Pre-existing Secret |
-| AWS Bedrock | Access Key/Secret, Pre-existing Secret |
-| Google Vertex AI | Service Account JSON (base64-encoded), Pre-existing Secret |
-| Custom OpenAI-compatible | API Key (inline or pre-existing Secret) |
+| Azure OpenAI | API Key, Existing Secret |
+| AWS Bedrock | Access Key/Secret, Existing Secret |
+| Google Vertex AI | Service Account JSON (base64-encoded), Existing Secret |
+| Custom OpenAI-compatible | API Key (inline or existing Secret) |
 
-## Configuration settings
+## Autopilot Service configuration
+
+The `values.yaml` file defines the deployment, networking, authentication, provider credentials, and model-list settings for the Autopilot Service.
+
+### Configuration settings
 
 | Configuration | Usage |
 |---|---|
-| `enabled` | Enable the Autopilot Service deployment as a backing service. Set this parameter to `true` to deploy the service. |
-| `deployment.name` | Specify the name of your Autopilot Service deployment. Your deployment creates resources prefixed with this string. |
+| `enabled` | Set this parameter to `true` to deploy the Autopilot Service as a backing service. |
+| `deployment.name` | Specify the deployment name. The chart prefixes Autopilot resources with this value. Default: `autopilot` |
 | `docker.registry.url` | Specify the image registry URL. |
-| `docker.registry.username` | Specify the username for the Docker registry. |
-| `docker.registry.password` | Specify the password for the Docker registry. |
-| `docker.imagePullSecretNames` | List pre-existing secrets to be used for pulling Docker images. |
-| `docker.autopilot.image` | Specify the Autopilot Service Docker image and tag. |
-| `docker.autopilot.imagePullPolicy` | Specify the image pull policy. Default is `Always`. |
-| `replicas` | Number of pod replicas to provision. Default is `2`. |
-| `service.port` | Defines the port used by the Service. Default is `80`. |
-| `service.targetPort` | Defines the port used by the Pod and Container. Default is `8080`. |
-| `service.serviceType` | The [type of service](https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) you wish to expose. Default is `ClusterIP`. |
-| `enableGenaiHub` | Set to `false` for on-prem deployments with direct provider connectivity. Default is `false`. |
-| `authEnabled` | Enable or disable authentication for the service. Default is `false`. |
-| `isInternalDeployment` | Set to `false` for on-prem deployments. Default is `false`. |
-| `modelProviders` | All models from the model list are displayed regardless of provider. For PCFG or Fedramp set the Bedrock as provider. |
-| `awsRegion` | AWS region for Bedrock. Default is `us-east-1`. |
-| `affinity` | Define pod affinity so that it is restricted to run on particular node(s), or to prefer to run on particular nodes. |
-| `tolerations` | Define pod tolerations so that it is allowed to run on node(s) with particular taints. |
+| `docker.registry.username` | Specify the image registry username. |
+| `docker.registry.password` | Specify the image registry password. |
+| `docker.imagePullSecretNames` | Specify an array of existing image pull Secrets to use when pulling images. |
+| `docker.autopilot.image` | Specify the Autopilot Service image and tag. |
+| `docker.autopilot.imagePullPolicy` | Specify the image pull policy. Default: `IfNotPresent` |
+| `replicas` | Specify the number of Autopilot pods. Default: `2` |
+| `resources` | Define CPU and memory requests and limits for the Autopilot container. |
+| `service.port` | Specify the Kubernetes Service port. Default: `80` |
+| `service.targetPort` | Specify the container port exposed by the service. Default: `8080` |
+| `service.serviceType` | Specify the Kubernetes Service type. Default: `ClusterIP` |
+| `enableGenaiHub` | Leave this parameter as `false` for client-managed cloud or on-premises deployments that connect directly to providers. Set it to `true` only when requests must be routed through the Pega GenAI Hub gateway. |
+| `authEnabled` | Set this parameter to `true` to require OAuth bearer tokens from Pega Platform. Default: `false` |
+| `oauthPublicKeyURL` | Specify the identity provider public key endpoint used to validate incoming bearer tokens. This value is required when `authEnabled` is `true`. |
+| `isInternalDeployment` | Leave this parameter as `false` for client-managed cloud or on-premises deployments. |
+| `modelProviders` | Specify a comma-separated list of providers to expose, such as `"Azure,Vertex,Bedrock"`. If this value is empty, the service relies on the configured credentials and model list. For FedRAMP or PCFG environments, set `"Bedrock"` as the provider. |
+| `awsRegion` | Specify the AWS region used by Bedrock. Default: `us-east-1` |
+| `affinity` | Define pod affinity rules. |
+| `tolerations` | Define pod tolerations. |
 
 ## Provider credentials
 
-The Autopilot Service supports two methods for providing LLM provider credentials.
+The Autopilot Service supports two credential patterns for Azure OpenAI, AWS Bedrock, and Google Vertex AI.
 
-### Option 1: Inline credentials (auto-creates Kubernetes Secret)
+### Option 1: Inline credentials
 
-Specify provider credentials directly in your values file. The chart automatically creates a Kubernetes Secret containing these values.
+Specify provider credentials directly in your values file. When you use inline credentials, the chart automatically creates a Kubernetes Secret named `<deployment.name>-provider-credentials`.
 
 | Configuration | Usage |
 |---|---|
-| `azure.endpoint` | Azure OpenAI endpoint URL (e.g., `https://my-openai.openai.azure.com/`). |
+| `azure.endpoint` | Azure OpenAI endpoint URL, for example `https://YOUR_AZURE_RESOURCE.openai.azure.com/`. |
 | `azure.apiKey` | Azure OpenAI API key. |
-| `azure.apiVersion` | Azure OpenAI API version. Default is `2024-10-21`. |
+| `azure.apiVersion` | Azure OpenAI API version. Default: `2024-10-21` |
 | `aws.accessKeyId` | AWS access key ID for Bedrock. |
 | `aws.secretAccessKey` | AWS secret access key for Bedrock. |
 | `aws.sessionToken` | Optional AWS session token for temporary credentials. |
-| `vertex.credentials` | Base64-encoded Google service account JSON key. The `project_id` is automatically extracted from the JSON. |
-| `vertex.location` | Vertex AI location. Default is `us-central1`. |
+| `vertex.credentials` | Base64-encoded Google service account JSON. The `project_id` is automatically extracted from the JSON. |
+| `vertex.location` | Vertex AI location. Default: `us-central1` |
 
 ```yaml
 autopilot:
   enabled: true
   azure:
-    endpoint: "https://my-openai.openai.azure.com/"
-    apiKey: "your-azure-api-key"
+    endpoint: "https://YOUR_AZURE_RESOURCE.openai.azure.com/"
+    apiKey: "YOUR_AZURE_OPENAI_API_KEY"
   aws:
-    accessKeyId: "AKIAIOSFODNN7EXAMPLE"
-    secretAccessKey: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+    accessKeyId: "YOUR_AWS_ACCESS_KEY_ID"
+    secretAccessKey: "YOUR_AWS_SECRET_ACCESS_KEY"
+    sessionToken: ""
   vertex:
-    credentials: "base64-encoded-service-account-json"
+    credentials: "YOUR_BASE64_ENCODED_VERTEX_SERVICE_ACCOUNT_JSON"
     location: "us-central1"
 ```
 
-#### Updating credentials after deployment (Option 1)
+#### Updating inline credentials after deployment
 
-When credentials change, run `helm upgrade` with the updated values file. The chart will re-encode and replace the Kubernetes Secret automatically:
+When credentials change, run `helm upgrade` with the updated values file. The chart automatically re-encodes and replaces the Kubernetes Secret:
 
 ```bash
 helm upgrade <RELEASE-NAME> <CHART-PATH> \
@@ -92,108 +99,107 @@ helm upgrade <RELEASE-NAME> <CHART-PATH> \
   --wait --timeout 5m
 ```
 
-> **Do not manually patch the Secret when using inline credentials.** The chart uses `b64enc` to encode values into the Secret. Patching the Secret directly will cause double base64 encoding and result in invalid credentials.
+> **Do not manually patch the Secret when using inline credentials.** The chart uses `b64enc` to encode values into the Secret. Patching the Secret directly can cause double base64 encoding and result in invalid credentials.
 
-### Option 2: Pre-existing Kubernetes Secret
+### Option 2: Existing Kubernetes Secret
 
-Use a secret that you create and manage outside of this chart. Set `providerCredentialsSecret` to the name of your secret. The secret should contain keys matching the environment variable names used by the service.
+Use a Secret that you create and manage outside of this chart. Set `providerCredentialsSecret` to the name of your Secret. The Secret should contain keys that match the environment variable names used by the service.
 
 | Configuration | Usage |
 |---|---|
-| `providerCredentialsSecret` | Name of an existing Kubernetes Secret containing provider credentials. When set, inline credentials are ignored. |
+| `providerCredentialsSecret` | Name of an existing Kubernetes Secret that contains provider credentials. When set, inline credentials are ignored. |
 
-The secret can contain credentials for all providers in a single secret. Only the keys relevant to the providers you are using need to be present — all keys are mounted as `optional: true` so missing keys are silently ignored.
+The Secret can contain credentials for all providers in a single Secret. Only the keys that are relevant to the providers you are using need to be present. All keys are mounted as `optional: true`, so missing keys are silently ignored.
 
 | Key | Provider | Description |
 |---|---|---|
-| `AZURE_ENDPOINT` | Azure OpenAI | Azure OpenAI endpoint URL (e.g. `https://my-openai.openai.azure.com/`) |
+| `AZURE_ENDPOINT` | Azure OpenAI | Azure OpenAI endpoint URL |
 | `AZURE_OPENAI_KEY` | Azure OpenAI | Azure OpenAI API key |
 | `AWS_ACCESS_KEY_ID` | AWS Bedrock | AWS access key ID |
 | `AWS_SECRET_ACCESS_KEY` | AWS Bedrock | AWS secret access key |
-| `AWS_SESSION_TOKEN` | AWS Bedrock | AWS session token (optional, for temporary credentials) |
-| `VERTEX_AUTH` | Google Vertex AI | Base64-encoded Google service account JSON. The Autopilot service base64-decodes this value itself, so the secret must hold the base64 string — not the raw JSON. |
+| `AWS_SESSION_TOKEN` | AWS Bedrock | Optional AWS session token |
+| `VERTEX_AUTH` | Google Vertex AI | Base64-encoded Google service account JSON. The Autopilot Service base64-decodes this value itself, so the Secret must contain the base64 string rather than the raw JSON. |
 
 ```yaml
 autopilot:
   enabled: true
-  providerCredentialsSecret: "my-provider-credentials"
+  providerCredentialsSecret: "autopilot-provider-credentials"
 ```
 
-Create the secret with credentials for all providers you intend to use. For `VERTEX_AUTH`, pass the base64-encoded JSON using `$(base64 -w0 ...)` so the pod receives the encoded string the service expects:
+Create the Secret with credentials for all providers that you intend to use. For `VERTEX_AUTH`, pass the base64-encoded JSON so the pod receives the encoded string the service expects:
 
 ```bash
-kubectl create secret generic my-provider-credentials \
+kubectl create secret generic autopilot-provider-credentials \
   --namespace <NAMESPACE> \
-  --from-literal=AZURE_ENDPOINT="https://my-openai.openai.azure.com/" \
-  --from-literal=AZURE_OPENAI_KEY="your-azure-api-key" \
-  --from-literal=AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE" \
-  --from-literal=AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
-  --from-literal=AWS_SESSION_TOKEN="your-session-token" \
+  --from-literal=AZURE_ENDPOINT="https://YOUR_AZURE_RESOURCE.openai.azure.com/" \
+  --from-literal=AZURE_OPENAI_KEY="YOUR_AZURE_OPENAI_API_KEY" \
+  --from-literal=AWS_ACCESS_KEY_ID="YOUR_AWS_ACCESS_KEY_ID" \
+  --from-literal=AWS_SECRET_ACCESS_KEY="YOUR_AWS_SECRET_ACCESS_KEY" \
+  --from-literal=AWS_SESSION_TOKEN="YOUR_AWS_SESSION_TOKEN" \
   --from-literal=VERTEX_AUTH="$(base64 -w0 /path/to/gcp-service-account.json)"
 ```
 
-You can also create the secret from a YAML manifest to manage it in source control. For `VERTEX_AUTH`, put the base64-encoded JSON string directly in `stringData`:
+You can also create the Secret from a YAML manifest to manage it in source control. For `VERTEX_AUTH`, put the base64-encoded JSON string directly in `stringData`:
 
 ```yaml
 apiVersion: v1
 kind: Secret
 metadata:
-  name: my-provider-credentials
+  name: autopilot-provider-credentials
   namespace: <NAMESPACE>
 type: Opaque
 stringData:
-  AZURE_ENDPOINT: "https://my-openai.openai.azure.com/"
-  AZURE_OPENAI_KEY: "your-azure-api-key"
-  AWS_ACCESS_KEY_ID: "AKIAIOSFODNN7EXAMPLE"
-  AWS_SECRET_ACCESS_KEY: "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
-  AWS_SESSION_TOKEN: "your-session-token"   # omit if not using temporary credentials
-  VERTEX_AUTH: "<base64-encoded-gcp-service-account-json>"  # base64 encode the JSON file: base64 -w0 gcp-service-account.json
+  AZURE_ENDPOINT: "https://YOUR_AZURE_RESOURCE.openai.azure.com/"
+  AZURE_OPENAI_KEY: "YOUR_AZURE_OPENAI_API_KEY"
+  AWS_ACCESS_KEY_ID: "YOUR_AWS_ACCESS_KEY_ID"
+  AWS_SECRET_ACCESS_KEY: "YOUR_AWS_SECRET_ACCESS_KEY"
+  AWS_SESSION_TOKEN: "YOUR_AWS_SESSION_TOKEN"   # omit if not using temporary credentials
+  VERTEX_AUTH: "YOUR_BASE64_ENCODED_VERTEX_SERVICE_ACCOUNT_JSON"  # base64 encode the JSON file: base64 -w0 gcp-service-account.json
 ```
 
-#### Updating credentials after deployment (Option 2)
+#### Updating a credentials Secret after deployment
 
 When credentials change, patch the existing Secret directly and restart the pod to pick up the new values:
 
 ```bash
-# Replace the secret with updated values
-kubectl create secret generic my-provider-credentials \
+# Replace the Secret with updated values
+kubectl create secret generic autopilot-provider-credentials \
   --namespace <NAMESPACE> \
-  --from-literal=AZURE_ENDPOINT="https://my-openai.openai.azure.com/" \
-  --from-literal=AZURE_OPENAI_KEY="your-azure-api-key" \
-  --from-literal=AWS_ACCESS_KEY_ID="AKIAIOSFODNN7EXAMPLE" \
-  --from-literal=AWS_SECRET_ACCESS_KEY="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" \
-  --from-literal=AWS_SESSION_TOKEN="your-session-token" \
+  --from-literal=AZURE_ENDPOINT="https://YOUR_AZURE_RESOURCE.openai.azure.com/" \
+  --from-literal=AZURE_OPENAI_KEY="YOUR_AZURE_OPENAI_API_KEY" \
+  --from-literal=AWS_ACCESS_KEY_ID="YOUR_AWS_ACCESS_KEY_ID" \
+  --from-literal=AWS_SECRET_ACCESS_KEY="YOUR_AWS_SECRET_ACCESS_KEY" \
+  --from-literal=AWS_SESSION_TOKEN="YOUR_AWS_SESSION_TOKEN" \
   --from-literal=VERTEX_AUTH="$(base64 -w0 /path/to/gcp-service-account.json)" \
   --dry-run=client -o yaml | kubectl apply -f -
 
-# Restart the pod to pick up the updated secret
+# Restart the pod to pick up the updated Secret
 kubectl rollout restart deployment/<DEPLOYMENT-NAME> -n <NAMESPACE>
 kubectl rollout status deployment/<DEPLOYMENT-NAME> -n <NAMESPACE> --timeout=120s
 ```
 
-## Custom models configuration
+## Model list configuration
 
-The Autopilot Service uses a model list to determine which LLM models are available. The service routes requests to the appropriate provider endpoint based on the model metadata in each entry. The `model_id` field format differs by provider — see [Building model list](#building-model-list) below for the rules per provider.
+The Autopilot Service uses a model list to determine which models are available and how requests are routed to each provider. When a model list is mounted by the chart, the container receives it through the `LOCAL_MODELS_FILE` environment variable at `/config/models.json`. The `model_id` field format differs by provider.
 
-## Building model list
+### Building model list
 
-### For Azure OpenAI and Vertex AI
+#### For Azure OpenAI and Vertex AI
 
-- **`name`** — Must match the deployment name as it appears in the LLM provider console (e.g., the Azure OpenAI Studio deployment name, or the Vertex AI model ID shown in Model Garden). This value is used as the display name and routing key.
-- **`model_path`** — Must be provided as an array of API endpoint paths relative to the provider base URL. For Azure OpenAI the path embeds the Azure portal deployment name (e.g., `["/openai/deployments/gpt-5/chat/completions"]`). For Vertex AI it embeds the model identifier (e.g., `["/google/deployments/gemini-2.5-pro/chat/completions"]`).
+- **`name`** must match the deployment name as it appears in the LLM provider console (for example, the Azure OpenAI Studio deployment name or the Vertex AI model ID shown in Model Garden). This value is used as the display name and routing key.
+- **`model_path`** must be provided as an array of API endpoint paths relative to the provider base URL. For Azure OpenAI, the path embeds the Azure portal deployment name (for example, `["/openai/deployments/gpt-5/chat/completions"]`). For Vertex AI, it embeds the model identifier (for example, `["/google/deployments/gemini-2.5-pro/chat/completions"]`).
 
-### For AWS Bedrock
+#### For AWS Bedrock
 
-- **`model_id`** — Must be the **exact model ID as shown in the AWS Bedrock console**, including the cross-region inference prefix and version suffix (e.g., `us.anthropic.claude-3-7-sonnet-20250219-v1:0`, `us.amazon.nova-pro-v1:0`, `amazon.titan-embed-text-v2:0`).
+- **`model_id`** must be the exact model ID as shown in the AWS Bedrock console, including the cross-region inference prefix and version suffix (for example, `us.anthropic.claude-3-7-sonnet-20250219-v1:0`, `us.amazon.nova-pro-v1:0`, `amazon.titan-embed-text-v2:0`).
 
+### Option 1: Bundled models file (recommended)
 
-### Option 1: Use the default models file bundled with the chart (recommended)
-
-The chart includes a `files/default-models.json` file containing a curated list of models for all supported providers. Setting `deployModelsConfigMap: true` (the default) automatically creates a ConfigMap from this file during `helm install` or `helm upgrade`.
+By default, the chart creates a ConfigMap from `files/default-models.json` during `helm install` or `helm upgrade`.
 
 | Configuration | Usage |
 |---|---|
-| `deployModelsConfigMap` | Set to `true` to create a ConfigMap from the bundled `files/default-models.json`. Default is `true`. |
+| `deployModelsConfigMap` | Set to `true` to create a ConfigMap from the bundled `files/default-models.json` file. Default: `true` |
 
 ```yaml
 autopilot:
@@ -203,9 +209,9 @@ autopilot:
 
 To customize the default model list before deployment, edit `files/default-models.json` in the chart directory.
 
-#### Updating the model list after deployment (Option 1)
+#### Updating the bundled model list after deployment
 
-After editing `files/default-models.json`, apply the changes to the running deployment without a full `helm upgrade`:
+After you edit `files/default-models.json`, apply the changes to the running deployment without a full `helm upgrade`:
 
 ```bash
 # Update the ConfigMap from the bundled file
@@ -219,49 +225,49 @@ kubectl rollout restart deployment/<DEPLOYMENT-NAME> -n <NAMESPACE>
 kubectl rollout status deployment/<DEPLOYMENT-NAME> -n <NAMESPACE> --timeout=120s
 ```
 
-### Option 2: Provide a pre-existing ConfigMap
+### Option 2: Existing ConfigMap
 
-Use a ConfigMap that you create and manage outside of this chart. The ConfigMap must contain a key named `models.json` with the model list as JSON content.
+Use a ConfigMap that you create and manage outside of this chart. The ConfigMap must include a `models.json` key.
 
 | Configuration | Usage |
 |---|---|
-| `customModels.existingConfigMap` | Name of an existing ConfigMap containing `models.json`. |
+| `customModels.existingConfigMap` | Name of an existing ConfigMap that contains `models.json`. |
 
 ```yaml
 autopilot:
   enabled: true
   deployModelsConfigMap: false
   customModels:
-    existingConfigMap: "my-models-configmap"
+    existingConfigMap: "autopilot-models"
 ```
 
 Create the ConfigMap:
 
 ```bash
-kubectl create configmap my-models-configmap \
+kubectl create configmap autopilot-models \
   --namespace <NAMESPACE> \
   --from-file=models.json=./my-models.json
 ```
 
-#### Updating the model list after deployment (Option 2)
+#### Updating a model list ConfigMap after deployment
 
 When the contents of your external ConfigMap change, re-apply it and restart the pod:
 
 ```bash
 # Re-apply the updated ConfigMap
-kubectl create configmap my-models-configmap \
+kubectl create configmap autopilot-models \
   --namespace <NAMESPACE> \
   --from-file=models.json=./my-models.json \
   --dry-run=client -o yaml | kubectl apply -f -
 
-# Restart the pod to pick up the new ConfigMap
+# Restart the pod to pick up the updated ConfigMap
 kubectl rollout restart deployment/<DEPLOYMENT-NAME> -n <NAMESPACE>
 kubectl rollout status deployment/<DEPLOYMENT-NAME> -n <NAMESPACE> --timeout=120s
 ```
 
-### Option 3: Inline model list in values
+### Option 3: Inline model list
 
-Provide the model JSON content directly in your values file. The chart creates a ConfigMap from this inline content.
+Specify the JSON content directly in `values.yaml`. The chart creates a ConfigMap from the inline content.
 
 | Configuration | Usage |
 |---|---|
@@ -295,29 +301,29 @@ autopilot:
       ]
 ```
 
-### Model JSON format
+If you set `deployModelsConfigMap: false` and do not provide `customModels.existingConfigMap` or `customModels.inline`, the service uses its built-in model list.
 
-Each model entry in the models file requires the following fields:
+### Model JSON format
 
 | Field | Required | Description |
 |---|---|---|
-| `provider` | Yes | Cloud provider (`azure`, `bedrock`, `vertex`). |
-| `creator` | Yes | Model creator (e.g., `openai`, `anthropic`, `google`, `amazon`). |
-| `model_name` | Yes | Model identifer name. |
-| `name` | Yes | **For Azure OpenAI and Vertex AI:** must match the deployment name as shown in the LLM provider console. Used as the display name and routing key. |
-| `model_id` | Yes | The provider-native model identifier. **For Azure OpenAI and Vertex AI:** the deployment name exactly as shown in the provider console — same value as `model_mapping_id` (e.g., `gpt-5-2025-08-07`, `gemini-2.5-pro`). **For Bedrock:** the exact model ID from the AWS Bedrock console, including cross-region prefix and version suffix (e.g., `us.anthropic.claude-3-7-sonnet-20250219-v1:0`, `us.amazon.nova-pro-v1:0`, `amazon.titan-embed-text-v2:0`). |
-| `model_mapping_id` | Yes | Provider-specific deployment name used for API routing and for constructing `model_path` entries. |
-| `model_path` | Yes | Array of API endpoint paths for the model, embedding the `model_mapping_id` value. **Azure OpenAI:** `["/openai/deployments/<model_mapping_id>/chat/completions"]`. **Vertex AI:** `["/google/deployments/<model_mapping_id>/chat/completions"]`. **Bedrock:** `["/anthropic/deployments/<model_mapping_id>/converse", "/anthropic/deployments/<model_mapping_id>/converse-stream"]` (adjust creator prefix to match). |
-| `type` | Yes | Model type: `chat_completion`, `embedding`, or `image`. |
+| `provider` | Yes | Provider name: `azure`, `bedrock`, `vertex`, or `custom`. |
+| `creator` | Yes | Model creator, for example `openai`, `anthropic`, `google`, or `amazon`. |
+| `model_name` | Yes | Display name for the model. |
+| `name` | Yes | Routing name used by the Autopilot Service. For Azure OpenAI and Vertex AI, this value must match the deployment name shown in the provider console. |
+| `model_id` | Yes | Provider-native model identifier. For Azure OpenAI and Vertex AI, use the deployment name as shown in the provider console. For AWS Bedrock, use the exact model ID from the AWS Bedrock console, including any cross-region prefix or version suffix. |
+| `model_mapping_id` | Yes | Deployment or provider-specific identifier used to build `model_path` entries. |
+| `model_path` | Yes | Array of API endpoint paths used by the service to reach the provider API. For Azure OpenAI, use `["/openai/deployments/<model_mapping_id>/chat/completions"]`. For Vertex AI, use `["/google/deployments/<model_mapping_id>/chat/completions"]`. For Bedrock, use `["/anthropic/deployments/<model_mapping_id>/converse", "/anthropic/deployments/<model_mapping_id>/converse-stream"]` (adjust the creator prefix to match the model creator). |
+| `type` | Yes | Model type, for example `chat_completion`, `embedding`, or `image`. |
 | `version` | Yes | Model version string. |
-| `input_tokens` | No | Maximum input token count. |
-| `output_tokens` | No | Maximum output token count. |
-| `supported_capabilities` | No | Object describing model capabilities (streaming, functions, multimodal, etc.). |
-| `parameters` | No | Object describing tunable parameters (temperature, top_p, max_tokens, etc.). |
+| `input_tokens` | No | Maximum supported input tokens. |
+| `output_tokens` | No | Maximum supported output tokens. |
+| `supported_capabilities` | No | Object that describes supported capabilities such as streaming, function calling, or multimodal support. |
+| `parameters` | No | Object that describes tunable model parameters, such as `temperature`, `top_p`, or `max_tokens`. |
 
 ## Default fast and smart models
 
-The `fast` and `smart` default models are now defined explicitly in a dedicated `default_models` section at the top level of the models JSON file.
+The `fast` and `smart` default models are defined explicitly in a dedicated `default_models` section at the top level of the models JSON file.
 
 The `default_models` section contains two keys — `fast` and `smart` — each holding the full model object of the intended default:
 
@@ -341,17 +347,17 @@ The `default_models` section contains two keys — `fast` and `smart` — each h
 
 To change which models serve as defaults, update the `default_models.fast` and `default_models.smart` entries in your models JSON file to the desired model objects. The model referenced must also be present in the `models` array.
 
-### Liveness and readiness probes
+## Liveness and readiness probes
 
 The Autopilot Service uses liveness and readiness probes on the `/v1/health` endpoint. Configure probes as part of a `livenessProbe` or `readinessProbe` configuration.
 
-Parameter             | Description    | Default `livenessProbe` | Default `readinessProbe`
----                   | ---            | ---                     | ---
-`initialDelaySeconds` | Number of seconds after the container has started before probes are initiated. | `10` | `10`
-`timeoutSeconds`      | Number of seconds after which the probe times out. | `10` | `10`
-`periodSeconds`       | How often (in seconds) to perform the probe. | `10` | `10`
-`successThreshold`    | Minimum consecutive successes for the probe to be considered successful after it determines a failure. | `1` | `1`
-`failureThreshold`    | The number of consecutive failures for the pod to be terminated by Kubernetes. | `3` | `3`
+| Parameter | Description | Default `livenessProbe` | Default `readinessProbe` |
+|---|---|---|---|
+| `initialDelaySeconds` | Number of seconds to wait before starting probes. | `10` | `10` |
+| `timeoutSeconds` | Probe timeout in seconds. | `10` | `10` |
+| `periodSeconds` | Probe interval in seconds. | `10` | `10` |
+| `successThreshold` | Minimum consecutive successes required after a failure. | `1` | `1` |
+| `failureThreshold` | Number of failures before Kubernetes marks the probe as failed. | `3` | `3` |
 
 Example:
 
@@ -372,16 +378,16 @@ readinessProbe:
 
 ## Ingress
 
-To expose the Autopilot Service externally, enable the ingress configuration.
+To expose the Autopilot Service outside the cluster, enable ingress.
 
 | Configuration | Usage |
 |---|---|
-| `ingress.enabled` | Set to `true` to deploy an ingress. Default is `false`. |
-| `ingress.domain` | Specify your custom domain. |
-| `ingress.ingressClassName` | Ingress class to be used. |
-| `ingress.tls.enabled` | Specify the use of HTTPS for ingress connectivity. |
-| `ingress.tls.secretName` | Specify the Kubernetes secret containing your SSL certificate. |
-| `ingress.annotations` | Specify additional annotations to add to the ingress. |
+| `ingress.enabled` | Leave as `false` unless you need to expose the Autopilot Service outside the cluster. |
+| `ingress.domain` | Specify the ingress host name. |
+| `ingress.ingressClassName` | Specify the ingress class name. |
+| `ingress.tls.enabled` | Set to `true` to enable TLS termination at the ingress. |
+| `ingress.tls.secretName` | Specify the Kubernetes Secret that stores the TLS certificate. |
+| `ingress.annotations` | Specify additional annotations for the ingress. |
 
 ```yaml
 ingress:
@@ -395,247 +401,243 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-body-size: "10m"
 ```
 
-## Connecting Pega Infinity with Autopilot Service
+## Connecting Pega Platform to the Autopilot Service
 
-After deploying the Autopilot Service, configure your Pega Infinity environment to connect to it. There are two ways to do this.
+After you deploy the Autopilot Service, configure Pega Platform to use the service URL using Dynamic System Setting (DSS) or `prconfig.xml`.
+
+> If both methods are configured, `prconfig.xml` takes precedence over the DSS.
 
 ### Option 1: Dynamic System Setting (DSS)
 
-1. Log in to Pega Infinity as an administrator.
-2. Navigate to **Records > SysAdmin > Dynamic System Settings** and create a new DSS with the following details:
+1. Log in to Pega Platform as an administrator.
+2. Navigate to **Records > SysAdmin > Dynamic System Settings** and create a new DSS with the following values:
 
 | Field | Value |
 |---|---|
-| **Owning Ruleset** | `Pega-Engine` |
-| **Setting Purpose** | `prconfig/services/genai/autopilot/servicebaseurl/default` |
-| **Value** | `http://<servicename>.<namespace>.svc.cluster.local/` |
+| Owning Ruleset | `Pega-Engine` |
+| Setting Purpose | `prconfig/services/genai/autopilot/servicebaseurl/default` |
+| Value | `http://<service-name>.<namespace>.svc.cluster.local:<service-port>/` |
 
-3. Replace `<servicename>` with the Autopilot Service name (default: `autopilot`) and `<namespace>` with the Kubernetes namespace where the service is deployed.
+3. Replace `<service-name>` with the Autopilot Service name (default: `autopilot`) and `<namespace>` with the Kubernetes namespace where the service is deployed.
 4. Save the DSS.
 
 **Example:** If the Autopilot Service is deployed with the default name `autopilot` in the `autopilot` namespace:
 
-```
+```text
 http://autopilot.autopilot.svc.cluster.local/
 ```
 
-5. **A restart of Pega Infinity nodes is required for the DSS change to take effect.**
+5. Restart Pega Platform nodes for the DSS change to take effect.
 
-### Option 2: prconfig.xml
+### Option 2: `prconfig.xml`
 
-Add the Autopilot service URL directly to `charts/pega/config/deploy/prconfig.xml` in the Pega Helm charts repository:
+Add the Autopilot Service URL directly to `charts/pega/config/deploy/prconfig.xml` in the Pega Helm charts repository:
 
 ```xml
-<env name="services/genai/autopilot/servicebaseurl" value="http://<servicename>.<namespace>.svc.cluster.local/"/>
+<env name="services/genai/autopilot/servicebaseurl" value="http://<service-name>.<namespace>.svc.cluster.local:<service-port>/"/>
 ```
 
-**Example:**
+Example:
 
 ```xml
 <env name="services/genai/autopilot/servicebaseurl" value="http://autopilot.autopilot.svc.cluster.local/"/>
 ```
 
-After editing `prconfig.xml`, apply the change with a `helm upgrade` followed by a rollout restart:
+After you edit `prconfig.xml`, apply the change with a `helm upgrade` followed by a rollout restart:
 
 ```bash
-helm upgrade pega <pega-chart-path> -f my-values.yaml -n <pega-namespace>
-kubectl rollout restart statefulset/<pega-deployment-name> -n <pega-namespace>
+helm upgrade pega <PEGA-CHART-PATH> -f my-values.yaml -n <PEGA-NAMESPACE>
+kubectl rollout restart statefulset/<PEGA-DEPLOYMENT-NAME> -n <PEGA-NAMESPACE>
 ```
 
-**A restart of Pega Infinity is required whenever the prconfig.xml entry is added or changed.**
+A restart of Pega Platform is required whenever the `prconfig.xml` entry is added or changed.
 
-### Precedence
+## OAuth authentication between Pega Platform and the Autopilot Service
 
-If the Autopilot service URL is configured by both methods, **`prconfig.xml` takes precedence over the DSS**.
-
-## OAuth authentication between Pega Infinity and the Autopilot service
-
-You can enable OAuth authentication to secure requests between Pega Infinity and the Autopilot service using an Identity Provider (IdP). The Autopilot service only supports the `private_key_jwt` authentication type.
+You can enable OAuth authentication to secure requests between Pega Platform and the Autopilot Service using an Identity Provider (IdP). The Autopilot Service only supports the `private_key_jwt` authentication type.
 
 ### How it works
 
-- Pega Infinity obtains a Bearer token from your IdP using an OAuth 2.0 `client_credentials` grant.
-- The token is attached as an `Authorization: Bearer <token>` header on every request to the Autopilot service.
-- The Autopilot service validates incoming tokens against the IdP public key endpoint (`oauthPublicKeyURL`).
+- Pega Platform obtains a bearer token from your IdP using an OAuth 2.0 `client_credentials` grant.
+- The token is attached as an `Authorization: Bearer <token>` header on every request to the Autopilot Service.
+- The Autopilot Service validates incoming tokens against the IdP public key endpoint (`oauthPublicKeyURL`).
 
 ### Scopes
 
-The Autopilot service does not require any OAuth scopes. Leave `autopilot.autopilotAuth.scopes` empty (or omit it entirely) when configuring the Pega chart.
+The Autopilot Service does not require any OAuth scopes. Leave `autopilot.autopilotAuth.scopes` empty (or omit it entirely) when configuring the Pega chart.
+
+### Autopilot Service configuration in the backingservices chart
+
+Enable auth on the Autopilot Service and set the IdP public key URL so it can validate incoming tokens:
+
+| Parameter | Description | Default |
+|---|---|---|
+| `authEnabled` | Enables token validation on incoming requests to the Autopilot Service. | `false` |
+| `oauthPublicKeyURL` | URL of the IdP public key endpoint used to verify bearer tokens. Required when `authEnabled` is `true`. | `""` |
+
+```yaml
+autopilot:
+  enabled: true
+  authEnabled: true
+  oauthPublicKeyURL: "https://YOUR_IDP_HOST/oauth2/v1/keys"
+```
+
+### Pega Platform configuration in the `pega` chart
+
+Configure the Pega chart to mint tokens and attach them to Autopilot requests. The Autopilot Service URL itself is configured via a DSS or `prconfig.xml` (see [Connecting Pega Platform to the Autopilot Service](#connecting-pega-platform-to-the-autopilot-service)) — no URL parameter is needed in the `pega` chart.
+
+| Parameter | Description | Default |
+|---|---|---|
+| `autopilot.autopilotAuth.enabled` | Enables OAuth token minting on the Pega Platform side. | `false` |
+| `autopilot.autopilotAuth.url` | URL of the OAuth service endpoint to obtain a token. | `""` |
+| `autopilot.autopilotAuth.clientId` | OAuth client ID. | `""` |
+| `autopilot.autopilotAuth.authType` | Authentication type. Only `private_key_jwt` is supported. | `"private_key_jwt"` |
+| `autopilot.autopilotAuth.privateKey` | Base64-encoded PKCS8 private key. | `""` |
+| `autopilot.autopilotAuth.privateKeyAlgorithm` | Algorithm for the private key. Allowed values: `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`. Default: `RS256` | `""` |
+| `autopilot.autopilotAuth.scopes` | OAuth scopes to request. The Autopilot Service does not require any scopes — leave this empty. | `""` |
+| `autopilot.autopilotAuth.external_secret_name` | Name of an existing Kubernetes Secret containing the key (key: `AUTOPILOT_OAUTH_PRIVATE_KEY`). When set, `privateKey` is ignored and no Secret is created by the chart. | `""` |
+
+```yaml
+autopilot:
+  autopilotAuth:
+    enabled: true
+    url: "https://YOUR_IDP_HOST/oauth2/v1/token"
+    clientId: "YOUR_CLIENT_ID"
+    authType: "private_key_jwt"
+    privateKey: "YOUR_BASE64_ENCODED_PKCS8_PRIVATE_KEY"
+    privateKeyAlgorithm: "RS256"
+    scopes: ""   # no scopes required for Autopilot
+```
+
+### Using an existing Secret for the private key
+
+To avoid placing the private key directly in `values.yaml`, create a Kubernetes Secret beforehand and reference it:
+
+```bash
+kubectl create secret generic autopilot-auth-secret \
+  --namespace <PEGA-NAMESPACE> \
+  --from-literal=AUTOPILOT_OAUTH_PRIVATE_KEY="YOUR_BASE64_ENCODED_PKCS8_PRIVATE_KEY"
+```
+
+Then reference the Secret in the `pega` chart:
+
+```yaml
+autopilot:
+  autopilotAuth:
+    enabled: true
+    external_secret_name: "autopilot-auth-secret"
+```
 
 ### Shared credentials with SRS and token-minting precedence
 
-Pega Infinity uses a single set of `SERV_AUTH_*` environment variables to mint Bearer tokens for backing services. When both SRS auth (`pegasearch.srsAuth`) and Autopilot auth (`autopilot.autopilotAuth`) are enabled at the same time, **the SRS credentials take precedence** and are used to mint tokens sent to both SRS and the Autopilot service.
+Pega Platform uses a single set of `SERV_AUTH_*` environment variables to mint bearer tokens for backing services. When both SRS auth (`pegasearch.srsAuth`) and Autopilot auth (`autopilot.autopilotAuth`) are enabled at the same time, **the SRS credentials take precedence** and are used to mint tokens sent to both SRS and the Autopilot Service.
 
 This means:
 
 - Both SRS and Autopilot can share the same IdP client application and credentials.
 - You do not need separate client registrations for each backing service if both are pointed at the same IdP authorization server.
 - If only `autopilot.autopilotAuth` is enabled (SRS auth is disabled), the Autopilot credentials are used to mint tokens.
-- If both are enabled and credentials differ, the SRS credentials win — the Autopilot-specific credentials are not used for token minting.
+- If both are enabled and the credentials differ, the SRS credentials win — the Autopilot-specific credentials are not used for token minting.
 
 In practice, configure both backing services to trust the same IdP public key endpoint and issue tokens from the same client application. The recommended setup when both services are deployed together:
 
 ```yaml
-# pega chart values
 pegasearch:
   srsAuth:
     enabled: true
-    url: "https://your-idp-host/oauth2/v1/token"
-    clientId: "your-shared-client-id"
+    url: "https://YOUR_IDP_HOST/oauth2/v1/token"
+    clientId: "YOUR_SHARED_CLIENT_ID"
     authType: "private_key_jwt"
-    privateKey: "LS0tLS1CRUdJTiBSU0Eg...<base64-encoded-PKCS8-key>"
-
+    privateKey: "YOUR_BASE64_ENCODED_PKCS8_PRIVATE_KEY"
 autopilot:
   autopilotAuth:
     enabled: true
-    url: "https://your-idp-host/oauth2/v1/token"
-    clientId: "your-shared-client-id"
-    privateKey: "LS0tLS1CRUdJTiBSU0Eg...<base64-encoded-PKCS8-key>"
+    url: "https://YOUR_IDP_HOST/oauth2/v1/token"
+    clientId: "YOUR_SHARED_CLIENT_ID"
+    privateKey: "YOUR_BASE64_ENCODED_PKCS8_PRIVATE_KEY"
     scopes: ""   # Autopilot requires no scopes
 ```
 
 Because SRS takes precedence, the token sent to Autopilot is minted using the SRS credentials above. Both services must therefore trust tokens issued for the same client.
 
-### Autopilot service configuration (backingservices chart)
-
-Enable auth on the Autopilot service and set the IdP public key URL so it can validate incoming tokens:
-
-| Parameter | Description | Default |
-|---|---|---|
-| `authEnabled` | Enables token validation on incoming requests to the Autopilot service. | `false` |
-| `oauthPublicKeyURL` | URL of the IdP public key endpoint used to verify Bearer tokens. Required when `authEnabled` is `true`. | `""` |
-
-```yaml
-autopilot:
-  enabled: true
-  authEnabled: true
-  oauthPublicKeyURL: "https://your-idp-host/oauth2/v1/keys"
-```
-
-### Pega Infinity configuration (pega chart)
-
-Configure the Pega chart to mint tokens and attach them to Autopilot requests. The Autopilot service URL itself is configured via a DSS in Pega Infinity (see "Connecting Pega Infinity with Autopilot Service" above) — no URL parameter is needed in the pega chart.
-
-| Parameter | Description | Default |
-|---|---|---|
-| `autopilot.autopilotAuth.enabled` | Enables OAuth token minting on the Pega Infinity side. | `false` |
-| `autopilot.autopilotAuth.url` | URL of the OAuth service endpoint to obtain a token. | `""` |
-| `autopilot.autopilotAuth.clientId` | OAuth client ID. | `""` |
-| `autopilot.autopilotAuth.authType` | Authentication type. Only `private_key_jwt` is supported. | `"private_key_jwt"` |
-| `autopilot.autopilotAuth.privateKey` | Base64-encoded PKCS8 private key. | `""` |
-| `autopilot.autopilotAuth.privateKeyAlgorithm` | Algorithm for the private key. Allowed values: `RS256`, `RS384`, `RS512`, `ES256`, `ES384`, `ES512`. Defaults to `RS256` if not set. | `""` |
-| `autopilot.autopilotAuth.scopes` | OAuth scopes to request. The Autopilot service does not require any scopes — leave this empty. | `""` |
-| `autopilot.autopilotAuth.external_secret_name` | Name of a pre-existing Kubernetes Secret containing the key (key: `AUTOPILOT_OAUTH_PRIVATE_KEY`). When set, `privateKey` is ignored and no secret is created by the chart. | `""` |
-
-```yaml
-autopilot:
-  autopilotAuth:
-    enabled: true
-    url: "https://your-idp-host/oauth2/v1/token"
-    clientId: "your-client-id"
-    privateKey: "LS0tLS1CRUdJTiBSU0Eg...<base64-encoded-PKCS8-key>"
-    privateKeyAlgorithm: "RS256"
-    scopes: ""   # no scopes required for Autopilot
-```
-
-### Using a pre-existing secret
-
-To avoid placing the private key directly in `values.yaml`, create a Kubernetes Secret beforehand and reference it:
-
-```bash
-kubectl create secret generic my-autopilot-auth-secret \
-  --namespace <pega-namespace> \
-  --from-literal=AUTOPILOT_OAUTH_PRIVATE_KEY="<base64-encoded-PKCS8-key>"
-```
-
-Then set in the pega chart values:
-
-```yaml
-autopilot:
-  autopilotAuth:
-    enabled: true
-    external_secret_name: "my-autopilot-auth-secret"
-```
-
 ## Custom OpenAI-compatible providers
 
-The Autopilot Service supports any OpenAI-compatible LLM provider (such as OpenRouter, private LLM servers, or other hosted endpoints) through the `customOpenAI` configuration. Each provider is identified by a `creator` name that maps to environment variables and to the `creator` field in the model JSON.
+The Autopilot Service supports OpenAI-compatible providers (such as OpenRouter, private LLM servers, or other hosted endpoints) through the `customOpenAI` section. Each provider is identified by a `creator` value that maps to environment variables and to the `creator` field in the model JSON.
 
 ### Configuration settings
 
 | Configuration | Usage |
 |---|---|
-| `customOpenAI.providers` | List of custom OpenAI-compatible provider configurations. Each entry produces a set of env vars in the pod automatically. |
-| `customOpenAI.providers[].creator` | Unique identifier for the provider (e.g., `openrouter`, `my-llm-server`). Must match the `creator` field in model entries. The chart derives env var names from this value. |
-| `customOpenAI.providers[].baseUrl` | Base URL of the provider's OpenAI-compatible API (e.g., `https://openrouter.ai/api/v1`). |
-| `customOpenAI.providers[].apiKey` | API key for the provider. Stored in a Kubernetes Secret by the chart. |
-| `customOpenAI.existingSecret` | Name of a pre-existing Kubernetes Secret containing API keys. When set, `apiKey` fields are not required. |
+| `customOpenAI.providers` | List of custom OpenAI-compatible provider configurations. Each entry produces a set of environment variables in the pod. |
+| `customOpenAI.providers[].creator` | Provider identifier (for example, `openrouter`, `my-llm-server`). Must match the `creator` field in model entries. |
+| `customOpenAI.providers[].baseUrl` | Base URL for the provider API (for example, `https://openrouter.ai/api/v1`). |
+| `customOpenAI.providers[].apiKey` | Provider API key. The chart stores inline values in a Secret. |
+| `customOpenAI.existingSecret` | Name of an existing Secret that contains provider API keys. When set, `apiKey` fields are not required. |
 
-### How it works
+For each entry in `customOpenAI.providers`, the chart injects these environment variables into the pod:
 
-All environment variables are **constructed automatically by the Helm chart** from `customOpenAI.providers` — you do not set any of these manually.
+- `CUSTOM_OPENAI_PROVIDERS` as a comma-separated list of all `creator` values
+- `CUSTOM_OPENAI_<CREATOR>_BASE_URL` for the provider base URL
+- `CUSTOM_OPENAI_<CREATOR>_API_KEY` for the provider API key
 
-For each entry in `customOpenAI.providers`, the chart injects into the pod:
+`<CREATOR>` is the `creator` value uppercased with hyphens and dots replaced by underscores. For example, `creator: openrouter` produces `CUSTOM_OPENAI_OPENROUTER_BASE_URL` and `CUSTOM_OPENAI_OPENROUTER_API_KEY`.
 
-- `CUSTOM_OPENAI_PROVIDERS` — comma-separated list of all `creator` values, assembled by the chart (e.g., `openrouter,my-llm-server`)
-- `CUSTOM_OPENAI_<CREATOR>_BASE_URL` — the `baseUrl` value for that provider (plain env var)
-- `CUSTOM_OPENAI_<CREATOR>_API_KEY` — the `apiKey` for that provider (read from a Kubernetes Secret)
-
-`<CREATOR>` is the `creator` value uppercased with hyphens and dots replaced by underscores. For example, `creator: openrouter` → `CUSTOM_OPENAI_OPENROUTER_BASE_URL` / `CUSTOM_OPENAI_OPENROUTER_API_KEY`.
-
-### Option 1: Inline API key (auto-creates Kubernetes Secret)
-
-Provide credentials directly in your values file. The chart automatically creates a Kubernetes Secret.
+### Option 1: Inline API key
 
 ```yaml
-customOpenAI:
-  providers:
-    - creator: openrouter
-      baseUrl: https://openrouter.ai/api/v1
-      apiKey: "sk-or-v1-..."
+autopilot:
+  customOpenAI:
+    providers:
+      - creator: openrouter
+        baseUrl: "https://openrouter.ai/api/v1"
+        apiKey: "YOUR_OPENROUTER_API_KEY"
 ```
 
 Multiple providers can be configured at once:
 
 ```yaml
-customOpenAI:
-  providers:
-    - creator: openrouter
-      baseUrl: https://openrouter.ai/api/v1
-      apiKey: "sk-or-v1-..."
-    - creator: my-llm-server
-      baseUrl: https://my-llm.internal/v1
-      apiKey: "my-internal-key"
+autopilot:
+  customOpenAI:
+    providers:
+      - creator: openrouter
+        baseUrl: "https://openrouter.ai/api/v1"
+        apiKey: "YOUR_OPENROUTER_API_KEY"
+      - creator: my-llm-server
+        baseUrl: "https://my-llm.internal/v1"
+        apiKey: "YOUR_INTERNAL_API_KEY"
 ```
 
-### Option 2: Pre-existing Kubernetes Secret
+### Option 2: Existing Kubernetes Secret
 
-Create a secret manually and reference it via `existingSecret`. The secret must contain keys in the format `CUSTOM_OPENAI_<CREATOR>_API_KEY`.
+Create a Secret manually and reference it via `existingSecret`. When set, inline `apiKey` values are not required.
 
 ```yaml
-customOpenAI:
-  existingSecret: "my-custom-openai-secret"
-  providers:
-    - creator: openrouter
-      baseUrl: https://openrouter.ai/api/v1
-      # apiKey omitted — read from existingSecret
+autopilot:
+  customOpenAI:
+    existingSecret: "custom-openai-credentials"
+    providers:
+      - creator: openrouter
+        baseUrl: "https://openrouter.ai/api/v1"
+        # apiKey omitted — read from existingSecret
 ```
 
-Create the secret:
+The Secret must use keys in the format `CUSTOM_OPENAI_<CREATOR>_API_KEY`. For `creator: openrouter`, the required key is `CUSTOM_OPENAI_OPENROUTER_API_KEY`.
+
+Create the Secret:
 
 ```bash
-kubectl create secret generic my-custom-openai-secret \
+kubectl create secret generic custom-openai-credentials \
   --namespace <NAMESPACE> \
-  --from-literal=CUSTOM_OPENAI_OPENROUTER_API_KEY="sk-or-v1-..."
+  --from-literal=CUSTOM_OPENAI_OPENROUTER_API_KEY="YOUR_OPENROUTER_API_KEY"
 ```
 
 ### Adding custom OpenAI models to the model list
 
-Models for custom OpenAI-compatible providers use `provider: custom` in the model JSON. The `creator` field must match the `creator` value configured in `customOpenAI.providers`. The `name` field is the model identifier sent to the provider API.
+Models for custom OpenAI-compatible providers use `provider: "custom"` in the model JSON. The `creator` field must match the `creator` value configured in `customOpenAI.providers`. The `name` field is the model identifier sent to the provider API.
 
-> **Important:** `model_name` must not contain slashes. Use `name` for the actual API model identifier when it contains slashes (e.g., `openrouter/free`).
+> **Important:** `model_name` must not contain slashes. Use `name` for the actual API model identifier when it contains slashes (for example, `openrouter/free`).
 
-Example model entry for OpenRouter:
+Example model entry:
 
 ```json
 {
@@ -671,18 +673,18 @@ To use this model as the default fast and smart model, set it in the `default_mo
 }
 ```
 
-### Model JSON fields for custom provider
+### Model JSON fields for custom providers
 
 | Field | Description |
 |---|---|
 | `provider` | Must be `custom`. |
 | `creator` | Must match the `creator` value in `customOpenAI.providers`. Used to look up `CUSTOM_OPENAI_<CREATOR>_BASE_URL` and `CUSTOM_OPENAI_<CREATOR>_API_KEY`. |
 | `model_name` | Display name for the model. Must not contain slashes. |
-| `name` | Actual model identifier sent to the provider API as the `model=` parameter (e.g., `openrouter/free`, `openai/gpt-4o`). |
-| `model_path` | Array with the API path suffix appended to `baseUrl` (e.g., `["/chat/completions"]`). |
+| `name` | Actual model identifier sent to the provider API as the `model` parameter (for example, `openrouter/free`). |
+| `model_path` | Array with the API path suffix appended to `baseUrl` (for example, `["/chat/completions"]`). |
 | `model_id` | Must follow the format `custom/<creator>/<model_name>/<version>` (no slashes in `model_name`). |
 
-## Example: Full deployment configuration
+## Example deployment configuration
 
 ```yaml
 autopilot:
@@ -692,35 +694,37 @@ autopilot:
 
   docker:
     registry:
-      url: YOUR_REGISTRY_URL
-      username: YOUR_REGISTRY_USERNAME
-      password: YOUR_REGISTRY_PASSWORD
+      url: "YOUR_REGISTRY_URL"
+      username: "YOUR_REGISTRY_USERNAME"
+      password: "YOUR_REGISTRY_PASSWORD"
     autopilot:
-      image: YOUR_REGISTRY_URL/autopilot-service:latest
+      image: "YOUR_REGISTRY_URL/autopilot-service:YOUR_TAG"
       imagePullPolicy: Always
 
   replicas: 2
   enableGenaiHub: false
+  authEnabled: false
+  isInternalDeployment: false
   modelProviders: "Azure,Vertex,Bedrock"
   deployModelsConfigMap: true
 
   azure:
-    endpoint: "https://my-openai.openai.azure.com/"
-    apiKey: "your-azure-api-key"
+    endpoint: "https://YOUR_AZURE_RESOURCE.openai.azure.com/"
+    apiKey: "YOUR_AZURE_OPENAI_API_KEY"
 
   aws:
-    accessKeyId: "your-access-key-id"
-    secretAccessKey: "your-secret-access-key"
+    accessKeyId: "YOUR_AWS_ACCESS_KEY_ID"
+    secretAccessKey: "YOUR_AWS_SECRET_ACCESS_KEY"
 
   vertex:
-    credentials: "base64-encoded-service-account-json"
+    credentials: "YOUR_BASE64_ENCODED_VERTEX_SERVICE_ACCOUNT_JSON"
     location: "us-central1"
 
   customOpenAI:
     providers:
       - creator: openrouter
-        baseUrl: https://openrouter.ai/api/v1
-        apiKey: "sk-or-v1-..."
+        baseUrl: "https://openrouter.ai/api/v1"
+        apiKey: "YOUR_OPENROUTER_API_KEY"
 
   resources:
     requests:

--- a/charts/backingservices/charts/autopilot/values.yaml
+++ b/charts/backingservices/charts/autopilot/values.yaml
@@ -14,7 +14,7 @@ docker:
     url: YOUR_DOCKER_REGISTRY_URL
     username: YOUR_DOCKER_REGISTRY_USERNAME
     password: YOUR_DOCKER_REGISTRY_PASSWORD
-  # List pre-existing secrets to be used for pulling docker images.
+  # List existing secrets to use for pulling Docker images.
   imagePullSecretNames: []
   autopilot:
     image: YOUR_AUTOPILOT_SERVICE_IMAGE:TAG
@@ -67,19 +67,20 @@ readinessProbe:
   failureThreshold: 3
 
 # -------------------------------------------------------------------
-# Autopilot service configuration
+# Autopilot Service configuration
 # -------------------------------------------------------------------
 
-# Set to false for on-prem (direct provider connectivity).
-# Set to true when using Pega GenAI Hub gateway.
+# Leave this parameter as false for client-managed cloud or on-premises deployments
+# that connect directly to LLM providers.
+# Set this parameter to true only when requests must be routed through the Pega GenAI Hub gateway.
 enableGenaiHub: false
 
-# Disable internal auth for on-prem deployments.
+# For client-managed cloud or on-premises deployments, leave both values as false.
 authEnabled: false
 isInternalDeployment: false
 
 # When authEnabled is true, set the URL of the Identity Provider (IdP) public key endpoint
-# so the Autopilot service can validate incoming OAuth Bearer tokens from Pega Infinity.
+# so the Autopilot Service can validate incoming OAuth Bearer tokens from Pega Platform.
 # Example: "https://your-idp-host/oauth2/v1/keys"
 oauthPublicKeyURL: ""
 
@@ -89,7 +90,7 @@ oauthPublicKeyURL: ""
 # Option 1: Use the default models file bundled with this chart (files/default-models.json).
 #   Set deployModelsConfigMap: true. To customize, edit files/default-models.json before helm install.
 #
-# Option 2: Provide a pre-existing ConfigMap name containing models.json
+# Option 2: Provide an existing ConfigMap name containing models.json
 #   customModels:
 #     existingConfigMap: "my-models-configmap"
 #
@@ -121,13 +122,13 @@ awsRegion: "us-east-1"
 # Provider credentials
 # -------------------------------------------------------------------
 # Option 1: Inline credentials (auto-creates a Kubernetes Secret)
-# Option 2: Use a pre-existing secret (set providerCredentialsSecret)
+# Option 2: Use an existing Secret (set providerCredentialsSecret)
 # -------------------------------------------------------------------
 
-# Pre-existing secret name containing provider credentials.
-# If set, inline credentials below are ignored.
-# The secret should contain keys matching the env var names
-# (e.g., AWS_ACCESS_KEY_ID, AZURE_ENDPOINT, AZURE_OPENAI_KEY, etc.)
+# Name of an existing Kubernetes Secret that stores provider credentials.
+# If set, the chart does not create a new Secret and ignores the inline credential values below.
+# Include only the keys for the providers that you use, for example AWS_ACCESS_KEY_ID,
+# AZURE_ENDPOINT, AZURE_OPENAI_KEY, or VERTEX_AUTH.
 providerCredentialsSecret: ""
 
 # --- Azure OpenAI credentials ---
@@ -167,7 +168,7 @@ vertex:
 # Secret options:
 #   Option 1 (default): Inline apiKey values → chart auto-creates Secret entries
 #     in the same provider-credentials Secret as Azure/AWS/Vertex.
-#   Option 2: Pre-existing Secret → set existingSecret to the Secret name.
+#   Option 2: Existing Secret → set existingSecret to the Secret name.
 #     The Secret must contain keys: CUSTOM_OPENAI_<CREATOR_UPPER>_API_KEY
 #     Inline apiKey values are ignored when existingSecret is set.
 #
@@ -182,7 +183,7 @@ vertex:
 #         apiKey: "secret"
 # -------------------------------------------------------------------
 customOpenAI:
-  existingSecret: ""   # pre-existing Secret name for API keys (optional)
+  existingSecret: ""   # existing Secret name for API keys (optional)
   providers: []
   # - creator: openrouter
   #   baseUrl: "https://openrouter.ai/api/v1"

--- a/charts/pega/templates/pega-autopilot-auth-secret.yaml
+++ b/charts/pega/templates/pega-autopilot-auth-secret.yaml
@@ -1,5 +1,5 @@
 {{- if and ((.Values.autopilot.autopilotAuth).enabled) (not .Values.autopilot.autopilotAuth.external_secret_name) }}
-# Secret for OAuth private key used to get an authorization token for Pega Infinity connection to the Autopilot service
+# Secret that stores the OAuth private key used by Pega Platform to obtain tokens for the Autopilot Service
 apiVersion: v1
 kind: Secret
 metadata:

--- a/charts/pega/templates/pega-environment-config.yaml
+++ b/charts/pega/templates/pega-environment-config.yaml
@@ -80,7 +80,8 @@ data:
   # URL to connect to Search and Reporting service
   SEARCH_AND_REPORTING_SERVICE_URL: {{ include "pegaSearchURL" $ }}
   # URL of the OAuth endpoint to get the token for Search and Reporting service
-  # Note: SRS OAuth takes precedence over Autopilot OAuth when both are enabled.
+  # When both Search and Reporting service and Autopilot Service use OAuth,
+  # the Search and Reporting service OAuth settings are used.
   SERV_AUTH_URL: "{{ .Values.pegasearch.srsAuth.url }}"
   # OAuth scopes to grant permissions for Pega Infinity in Search and Reporting service
   # The required value is "pega.search:full"
@@ -104,9 +105,9 @@ data:
   SRS_KEYSTORE_PATH: "/opt/pega/certs/{{ .Values.pegasearch.srsMTLS.keyStore }}"
 {{- end }}
 {{- if and (.Values.autopilot.autopilotAuth).enabled (not (and .Values.pegasearch.externalSearchService (.Values.pegasearch.srsAuth).enabled)) }}
-  # URL of the OAuth endpoint to get the token for the Autopilot service
+  # URL of the OAuth endpoint to get the token for the Autopilot Service
   SERV_AUTH_URL: "{{ .Values.autopilot.autopilotAuth.url }}"
-  # OAuth scopes to grant permissions for Pega Infinity in the Autopilot service
+  # OAuth scopes to grant permissions for Pega Platform in the Autopilot Service
   {{- if .Values.autopilot.autopilotAuth.scopes }}
   SERV_AUTH_SCOPES: {{ .Values.autopilot.autopilotAuth.scopes | quote }}
   {{- end }}

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -546,14 +546,15 @@ pegasearch:
     # Enter the external secret name below.
     external_secret_name: ""
 
-# Autopilot GenAI service settings.
-# Configure OAuth authentication between Pega Infinity and the on-premise Autopilot backing service.
-# The Autopilot service URL is configured separately via a Dynamic System Setting (DSS) in Pega Infinity.
+# Autopilot Service settings.
+# Configure OAuth authentication between Pega Platform and the Autopilot Service
+# in client-managed cloud or on-premises deployments.
+# In Pega Platform, you can also configure the Autopilot Service URL separately by using a Dynamic System Setting (DSS).
 autopilot:
   autopilotAuth:
-    # Set enabled to true to enable OAuth authentication between Pega Infinity and the Autopilot service.
+    # Set enabled to true to enable OAuth authentication between Pega Platform and the Autopilot Service.
     enabled: false
-    # URL of the OAuth service endpoint to get the token for the Autopilot service.
+    # URL of the OAuth service endpoint to get the token for the Autopilot Service.
     url: ""
     # Client ID used in the OAuth service.
     clientId: ""
@@ -564,11 +565,11 @@ autopilot:
     privateKey: ""
     # Algorithm used to generate the private key. Allowed values: RS256, RS384, RS512, ES256, ES384, ES512.
     privateKeyAlgorithm: ""
-    # Scopes set in the OAuth service required to grant access to the Autopilot service.
+    # OAuth scopes to request from the identity provider. Leave empty unless your identity provider requires scopes.
     scopes: ""
-    # Name of a pre-existing Kubernetes Secret containing the private key or client secret.
-    # When set, the chart does not create a new secret and ignores the privateKey value above.
-    # The secret must contain the key "AUTOPILOT_OAUTH_PRIVATE_KEY".
+    # Name of an existing Kubernetes Secret that contains the private key.
+    # When set, the chart does not create a new Secret and ignores the privateKey value above.
+    # The Secret must contain the key "AUTOPILOT_OAUTH_PRIVATE_KEY".
     external_secret_name: ""
 
 # Pega Installer settings.


### PR DESCRIPTION
In addition to the stylistic and linguistic review, I added the following changes that seemed to be missing from the original docs but are supported in the configuration.

| Location | What changed | Why |
|---|---|---|
| Config table | Added `resources` row | Original table didn't document this parameter |
| Config table | Added `oauthPublicKeyURL` row | Original table only mentioned this in the OAuth section further down |
| Config table | `imagePullPolicy` default stated as `IfNotPresent` | Original README said `Always`; corrected per `values.yaml` — **please confirm this is the intended default** |
| Inline credentials example | Added `sessionToken: ""` | Original example omitted this field |
| URL templates (DSS + prconfig) | Added `:<service-port>` to URL | Original used `<servicename>.<namespace>.svc.cluster.local/` without port |
| Full deployment example | Added `authEnabled: false` and `isInternalDeployment: false` | Not in original example, makes defaults explicit |
| Model list intro | Added `LOCAL_MODELS_FILE` env var and `/config/models.json` mount path | New technical detail not in original |
| Model list section | Added fallback note: "If you set `deployModelsConfigMap: false` and do not provide `customModels.existingConfigMap` or `customModels.inline`, the service uses its built-in model list." | Documents previously undocumented behaviour |