### PR TITLE
ENHANCEMENT-2018: Added pega version-gated configurable new health probes endpoints

### DIFF
--- a/charts/pega/templates/_helpers.tpl
+++ b/charts/pega/templates/_helpers.tpl
@@ -611,12 +611,32 @@ servicePort: use-annotation
   {{- end }}
 {{- end }}
 
-{{/* Checks if the Pega version supports the new separated health probe endpoints (>= 26.1.1) */}}
-{{- define "useNewHealthProbes" -}}
+{{/* Checks if the Pega version supports the enhancedz health probe endpoints */}}
+{{/* Supported: 2025.1.4+, 2026.1.1+, 2027+. Rejected: all 8.x versions */}}
+{{- define "areEnhancedHealthProbesSupported" -}}
   {{- if and .Values.global.newHealthProbes (eq (toString .Values.global.newHealthProbes.enabled) "true") -}}
     {{- if .Values.global.pegaVersion -}}
-      {{- if (semverCompare ">= 26.1.1-0" (trimPrefix "branch-" .Values.global.pegaVersion)) -}}
+      {{- $version := trimPrefix "branch-" .Values.global.pegaVersion -}}
+      {{- $parts := splitList "." $version -}}
+      {{- $major := int (index $parts 0) -}}
+      {{- $minor := 0 -}}
+      {{- if gt (len $parts) 1 -}}{{- $minor = int (index $parts 1) -}}{{- end -}}
+      {{- $patch := 0 -}}
+      {{- if gt (len $parts) 2 -}}{{- $patch = int (index $parts 2) -}}{{- end -}}
+      {{- if ge $major 2027 -}}
         true
+      {{- else if eq $major 2026 -}}
+        {{- if or (gt $minor 1) (and (eq $minor 1) (ge $patch 1)) -}}
+          true
+        {{- else -}}
+          false
+        {{- end -}}
+      {{- else if eq $major 2025 -}}
+        {{- if or (gt $minor 1) (and (eq $minor 1) (ge $patch 4)) -}}
+          true
+        {{- else -}}
+          false
+        {{- end -}}
       {{- else -}}
         false
       {{- end -}}

--- a/charts/pega/templates/_helpers.tpl
+++ b/charts/pega/templates/_helpers.tpl
@@ -610,3 +610,20 @@ servicePort: use-annotation
     "false"
   {{- end }}
 {{- end }}
+
+{{/* Checks if the Pega version supports the new separated health probe endpoints (>= 26.1.1) */}}
+{{- define "useNewHealthProbes" -}}
+  {{- if and .Values.global.newHealthProbes (eq (toString .Values.global.newHealthProbes.enabled) "true") -}}
+    {{- if .Values.global.pegaVersion -}}
+      {{- if (semverCompare ">= 26.1.1-0" (trimPrefix "branch-" .Values.global.pegaVersion)) -}}
+        true
+      {{- else -}}
+        false
+      {{- end -}}
+    {{- else -}}
+      false
+    {{- end -}}
+  {{- else -}}
+    false
+  {{- end -}}
+{{- end -}}

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -2,7 +2,7 @@
 {{- $useStartupProbe := false }}
 {{- $livenessProbe := .node.livenessProbe }}
 {{- $readinessProbe := .node.readinessProbe }}
-{{- $useNewProbes := (eq (include "useNewHealthProbes" .root) "true") }}
+{{- $useEnhancedProbes := (eq (include "areEnhancedHealthProbesSupported" .root) "true") }}
 {{- $livenessProbeInitialDelaySeconds := $livenessProbe.initialDelaySeconds | default 200 }}
 {{- $livenessProbeFailureThreshold := $livenessProbe.failureThreshold | default 3 }}
 {{- $livenessProbePeriodSeconds := $livenessProbe.periodSeconds | default 30 }}
@@ -12,14 +12,14 @@
   {{- $livenessProbeInitialDelaySeconds = $livenessProbe.initialDelaySeconds | default 0 }}
   {{- $readinessProbeInitialDelaySeconds = $readinessProbe.initialDelaySeconds | default 0 }}
 {{- end }}
-{{- if $useNewProbes }}
+{{- if $useEnhancedProbes }}
   {{- $livenessProbeInitialDelaySeconds = $livenessProbe.initialDelaySeconds | default 0 }}
   {{- $livenessProbeFailureThreshold = $livenessProbe.failureThreshold | default 3 }}
   {{- $livenessProbePeriodSeconds = $livenessProbe.periodSeconds | default 20 }}
   {{- $readinessProbeInitialDelaySeconds = $readinessProbe.initialDelaySeconds | default 0 }}
 {{- end }}
 {{- $newProbesRequestedButUnavailable := false }}
-{{- if and .root.Values.global.newHealthProbes (eq (toString .root.Values.global.newHealthProbes.enabled) "true") (not $useNewProbes) }}
+{{- if and .root.Values.global.newHealthProbes (eq (toString .root.Values.global.newHealthProbes.enabled) "true") (not $useEnhancedProbes) }}
   {{- $newProbesRequestedButUnavailable = true }}
 {{- end }}
 
@@ -192,7 +192,7 @@ spec:
 {{- end }}
 {{- end }}
         # Specify any of the container environment variables here
-        env:	
+        env:
         # Node type of the Pega nodes for {{ .name }}
 {{- if .root.Values.stream }}
 {{- if .root.Values.stream.url }}
@@ -345,7 +345,7 @@ spec:
         # LivenessProbe: indicates whether the container is live, i.e. running.
         livenessProbe:
           httpGet:
-{{- if $useNewProbes }}
+{{- if $useEnhancedProbes }}
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/liveness"
 {{- else }}
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/ping"
@@ -353,14 +353,14 @@ spec:
             port: {{ $livenessProbe.port | default 8080 }}
             scheme: HTTP
           initialDelaySeconds: {{ $livenessProbeInitialDelaySeconds }}
-          timeoutSeconds: {{ $livenessProbe.timeoutSeconds | default (ternary 5 20 $useNewProbes) }}
+          timeoutSeconds: {{ $livenessProbe.timeoutSeconds | default (ternary 5 20 $useEnhancedProbes) }}
           periodSeconds: {{ $livenessProbePeriodSeconds }}
           successThreshold: {{ $livenessProbe.successThreshold | default 1 }}
           failureThreshold: {{ $livenessProbeFailureThreshold }}
         # ReadinessProbe: indicates whether the container is ready to service requests.
         readinessProbe:
           httpGet:
-{{- if $useNewProbes }}
+{{- if $useEnhancedProbes }}
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/readiness"
 {{- else }}
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/ping"
@@ -368,7 +368,7 @@ spec:
             port: {{ $readinessProbe.port | default 8080 }}
             scheme: HTTP
           initialDelaySeconds: {{ $readinessProbeInitialDelaySeconds }}
-          timeoutSeconds: {{ $readinessProbe.timeoutSeconds | default (ternary 5 10 $useNewProbes) }}
+          timeoutSeconds: {{ $readinessProbe.timeoutSeconds | default (ternary 5 10 $useEnhancedProbes) }}
           periodSeconds: {{ $readinessProbe.periodSeconds | default 10 }}
           successThreshold: {{ $readinessProbe.successThreshold | default 1 }}
           failureThreshold: {{ $readinessProbe.failureThreshold | default 3 }}
@@ -377,7 +377,7 @@ spec:
         {{- $startupProbe := .node.startupProbe }}
         startupProbe:
           httpGet:
-{{- if $useNewProbes }}
+{{- if $useEnhancedProbes }}
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/startup"
 {{- else }}
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/ping"
@@ -385,10 +385,10 @@ spec:
             port: {{ $startupProbe.port | default 8080 }}
             scheme: HTTP
           initialDelaySeconds: {{ $startupProbe.initialDelaySeconds | default 10 }}
-          timeoutSeconds: {{ $startupProbe.timeoutSeconds | default (ternary 5 10 $useNewProbes) }}
+          timeoutSeconds: {{ $startupProbe.timeoutSeconds | default (ternary 5 10 $useEnhancedProbes) }}
           periodSeconds: {{ $startupProbe.periodSeconds | default 10 }}
           successThreshold: {{ $startupProbe.successThreshold | default 1 }}
-          failureThreshold: {{ $startupProbe.failureThreshold | default (ternary 60 30 $useNewProbes) }}
+          failureThreshold: {{ $startupProbe.failureThreshold | default (ternary 60 30 $useEnhancedProbes) }}
 {{- end }}
 
 {{- if .custom }}

--- a/charts/pega/templates/_pega-deployment.tpl
+++ b/charts/pega/templates/_pega-deployment.tpl
@@ -2,6 +2,7 @@
 {{- $useStartupProbe := false }}
 {{- $livenessProbe := .node.livenessProbe }}
 {{- $readinessProbe := .node.readinessProbe }}
+{{- $useNewProbes := (eq (include "useNewHealthProbes" .root) "true") }}
 {{- $livenessProbeInitialDelaySeconds := $livenessProbe.initialDelaySeconds | default 200 }}
 {{- $livenessProbeFailureThreshold := $livenessProbe.failureThreshold | default 3 }}
 {{- $livenessProbePeriodSeconds := $livenessProbe.periodSeconds | default 30 }}
@@ -10,6 +11,16 @@
   {{- $useStartupProbe = true }}
   {{- $livenessProbeInitialDelaySeconds = $livenessProbe.initialDelaySeconds | default 0 }}
   {{- $readinessProbeInitialDelaySeconds = $readinessProbe.initialDelaySeconds | default 0 }}
+{{- end }}
+{{- if $useNewProbes }}
+  {{- $livenessProbeInitialDelaySeconds = $livenessProbe.initialDelaySeconds | default 0 }}
+  {{- $livenessProbeFailureThreshold = $livenessProbe.failureThreshold | default 3 }}
+  {{- $livenessProbePeriodSeconds = $livenessProbe.periodSeconds | default 20 }}
+  {{- $readinessProbeInitialDelaySeconds = $readinessProbe.initialDelaySeconds | default 0 }}
+{{- end }}
+{{- $newProbesRequestedButUnavailable := false }}
+{{- if and .root.Values.global.newHealthProbes (eq (toString .root.Values.global.newHealthProbes.enabled) "true") (not $useNewProbes) }}
+  {{- $newProbesRequestedButUnavailable = true }}
 {{- end }}
 
 kind: {{ .kind }}
@@ -23,6 +34,9 @@ metadata:
 # Below are the annotations applied for specific tier
 {{- if .node.deploymentAnnotations }}
 {{ toYaml .node.deploymentAnnotations | indent 4 }}
+{{- end }}
+{{- if $newProbesRequestedButUnavailable }}
+    pega.io/health-probes-warning: "New separated health probes requested (global.newHealthProbes.enabled=true) but Pega version {{ .root.Values.global.pegaVersion | default "unset" }} is below 26.1.1. Falling back to legacy /ping probes."
 {{- end }}
   name: {{ .name }}
   namespace: {{ .root.Release.Namespace }}
@@ -331,22 +345,30 @@ spec:
         # LivenessProbe: indicates whether the container is live, i.e. running.
         livenessProbe:
           httpGet:
+{{- if $useNewProbes }}
+            path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/liveness"
+{{- else }}
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/ping"
+{{- end }}
             port: {{ $livenessProbe.port | default 8080 }}
             scheme: HTTP
           initialDelaySeconds: {{ $livenessProbeInitialDelaySeconds }}
-          timeoutSeconds: {{ $livenessProbe.timeoutSeconds | default 20 }}
+          timeoutSeconds: {{ $livenessProbe.timeoutSeconds | default (ternary 5 20 $useNewProbes) }}
           periodSeconds: {{ $livenessProbePeriodSeconds }}
           successThreshold: {{ $livenessProbe.successThreshold | default 1 }}
           failureThreshold: {{ $livenessProbeFailureThreshold }}
         # ReadinessProbe: indicates whether the container is ready to service requests.
         readinessProbe:
           httpGet:
+{{- if $useNewProbes }}
+            path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/readiness"
+{{- else }}
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/ping"
+{{- end }}
             port: {{ $readinessProbe.port | default 8080 }}
             scheme: HTTP
           initialDelaySeconds: {{ $readinessProbeInitialDelaySeconds }}
-          timeoutSeconds: {{ $readinessProbe.timeoutSeconds | default 10 }}
+          timeoutSeconds: {{ $readinessProbe.timeoutSeconds | default (ternary 5 10 $useNewProbes) }}
           periodSeconds: {{ $readinessProbe.periodSeconds | default 10 }}
           successThreshold: {{ $readinessProbe.successThreshold | default 1 }}
           failureThreshold: {{ $readinessProbe.failureThreshold | default 3 }}
@@ -355,14 +377,18 @@ spec:
         {{- $startupProbe := .node.startupProbe }}
         startupProbe:
           httpGet:
+{{- if $useNewProbes }}
+            path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/startup"
+{{- else }}
             path: "/{{ template "pega.applicationContextPath" . }}/PRRestService/monitor/pingService/ping"
+{{- end }}
             port: {{ $startupProbe.port | default 8080 }}
             scheme: HTTP
           initialDelaySeconds: {{ $startupProbe.initialDelaySeconds | default 10 }}
-          timeoutSeconds: {{ $startupProbe.timeoutSeconds | default 10 }}
+          timeoutSeconds: {{ $startupProbe.timeoutSeconds | default (ternary 5 10 $useNewProbes) }}
           periodSeconds: {{ $startupProbe.periodSeconds | default 10 }}
           successThreshold: {{ $startupProbe.successThreshold | default 1 }}
-          failureThreshold: {{ $startupProbe.failureThreshold | default 30 }}
+          failureThreshold: {{ $startupProbe.failureThreshold | default (ternary 60 30 $useNewProbes) }}
 {{- end }}
 
 {{- if .custom }}

--- a/charts/pega/values.yaml
+++ b/charts/pega/values.yaml
@@ -34,6 +34,14 @@ global:
   # https://docs.pega.com/bundle/platform/page/platform/security/enabling-fips-140-3.html
   highlySecureCryptoModeEnabled: false
 
+  # Enable new separated health probe endpoints (startup, liveness, readiness).
+  # Requires Pega Platform version >= 26.1.1. When enabled with a compatible version,
+  # probes use dedicated lightweight endpoints instead of the shared /ping endpoint.
+  # If enabled but pegaVersion is not set or is below 26.1.1, falls back to legacy /ping probes.
+  # Ensure global.pegaVersion is set when enabling this feature.
+  newHealthProbes:
+    enabled: false
+
   # If a storage class to be passed to the VolumeClaimTemplates in search and stream pods, it can be specified here:
   storageClassName: ""
   # Provide JDBC connection information to the Pega relational database

--- a/terratest/src/test/pega/pega-tier-deployment-health-probes_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment-health-probes_test.go
@@ -1,0 +1,396 @@
+package pega
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/gruntwork-io/terratest/modules/helm"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	k8score "k8s.io/api/core/v1"
+	intstr "k8s.io/apimachinery/pkg/util/intstr"
+)
+
+// TestPegaDeploymentLegacyHealthProbes verifies that when newHealthProbes is not enabled,
+// probes use the legacy /ping endpoint with legacy default values.
+func TestPegaDeploymentLegacyHealthProbes(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":        "eks",
+			"global.actions.execute": "deploy",
+			"global.deployment.name": "pega",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+	pod := depObj.Spec.Template.Spec
+
+	verifyLegacyProbes(t, &pod)
+}
+
+// TestPegaDeploymentNewHealthProbesEnabled verifies that when newHealthProbes.enabled=true
+// and pegaVersion >= 26.1.1, probes use the new separated endpoints with new defaults.
+func TestPegaDeploymentNewHealthProbesEnabled(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":              "eks",
+			"global.actions.execute":       "deploy",
+			"global.deployment.name":       "pega",
+			"global.newHealthProbes.enabled": "true",
+			"global.pegaVersion":           "26.2.0",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+	pod := depObj.Spec.Template.Spec
+
+	verifyNewProbes(t, &pod)
+
+	// Verify no fallback warning annotation
+	require.Empty(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"])
+}
+
+// TestPegaDeploymentNewHealthProbesWithExactVersion verifies behavior with exact threshold version 26.1.1
+func TestPegaDeploymentNewHealthProbesWithExactVersion(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":              "eks",
+			"global.actions.execute":       "deploy",
+			"global.deployment.name":       "pega",
+			"global.newHealthProbes.enabled": "true",
+			"global.pegaVersion":           "26.1.1",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+	pod := depObj.Spec.Template.Spec
+
+	// Exact version 26.1.1 should activate new probes (>= check)
+	verifyNewProbes(t, &pod)
+}
+
+// TestPegaDeploymentNewHealthProbesFallbackOlderVersion verifies that when newHealthProbes.enabled=true
+// but pegaVersion < 26.1.1, probes fall back to legacy /ping and a warning annotation is added.
+func TestPegaDeploymentNewHealthProbesFallbackOlderVersion(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":              "eks",
+			"global.actions.execute":       "deploy",
+			"global.deployment.name":       "pega",
+			"global.newHealthProbes.enabled": "true",
+			"global.pegaVersion":           "25.1.0",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+	pod := depObj.Spec.Template.Spec
+
+	// Should fall back to legacy probes
+	verifyLegacyProbes(t, &pod)
+
+	// Should have fallback warning annotation
+	require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "Falling back to legacy /ping probes")
+	require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "25.1.0")
+}
+
+// TestPegaDeploymentNewHealthProbesFallbackNoVersion verifies fallback when pegaVersion is not set at all.
+func TestPegaDeploymentNewHealthProbesFallbackNoVersion(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":              "eks",
+			"global.actions.execute":       "deploy",
+			"global.deployment.name":       "pega",
+			"global.newHealthProbes.enabled": "true",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+	pod := depObj.Spec.Template.Spec
+
+	// Should fall back to legacy probes when no version is set
+	verifyLegacyProbes(t, &pod)
+
+	// Should have fallback warning annotation
+	require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "Falling back to legacy /ping probes")
+}
+
+// TestPegaDeploymentNewHealthProbesVersion26_1_0 verifies that version 26.1.0 (just below threshold)
+// falls back to legacy probes.
+func TestPegaDeploymentNewHealthProbesVersion26_1_0(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":              "eks",
+			"global.actions.execute":       "deploy",
+			"global.deployment.name":       "pega",
+			"global.newHealthProbes.enabled": "true",
+			"global.pegaVersion":           "26.1.0",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+	pod := depObj.Spec.Template.Spec
+
+	// 26.1.0 is below 26.1.1, should use legacy
+	verifyLegacyProbes(t, &pod)
+
+	// Should have fallback warning annotation
+	require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "Falling back to legacy /ping probes")
+}
+
+// TestPegaDeploymentNewHealthProbesAppliedToAllTiers verifies that new probes apply
+// to all tiers (web and batch) when enabled globally.
+func TestPegaDeploymentNewHealthProbesAppliedToAllTiers(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var webDep appsv1.Deployment
+	var batchDep appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":              "eks",
+			"global.actions.execute":       "deploy",
+			"global.deployment.name":       "pega",
+			"global.newHealthProbes.enabled": "true",
+			"global.pegaVersion":           "26.2.0",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	// Web tier
+	UnmarshalK8SYaml(t, yamlSplit[1], &webDep)
+	verifyNewProbes(t, &webDep.Spec.Template.Spec)
+
+	// Batch tier
+	UnmarshalK8SYaml(t, yamlSplit[2], &batchDep)
+	verifyNewProbes(t, &batchDep.Spec.Template.Spec)
+}
+
+// TestPegaDeploymentNewHealthProbesWithCustomOverrides verifies that user-specified
+// probe values take precedence over new probe defaults.
+func TestPegaDeploymentNewHealthProbesWithCustomOverrides(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":                         "eks",
+			"global.actions.execute":                  "deploy",
+			"global.deployment.name":                  "pega",
+			"global.newHealthProbes.enabled":            "true",
+			"global.pegaVersion":                      "26.2.0",
+			"global.tier[0].name":                     "web",
+			"global.tier[0].livenessProbe.timeoutSeconds":    "15",
+			"global.tier[0].livenessProbe.periodSeconds":     "25",
+			"global.tier[0].livenessProbe.failureThreshold":  "5",
+			"global.tier[0].readinessProbe.timeoutSeconds":   "8",
+			"global.tier[0].readinessProbe.periodSeconds":    "15",
+			"global.tier[0].startupProbe.timeoutSeconds":     "12",
+			"global.tier[0].startupProbe.failureThreshold":   "45",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+	pod := depObj.Spec.Template.Spec
+
+	// Paths should still be the new separated endpoints
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/liveness", pod.Containers[0].LivenessProbe.HTTPGet.Path)
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/readiness", pod.Containers[0].ReadinessProbe.HTTPGet.Path)
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/startup", pod.Containers[0].StartupProbe.HTTPGet.Path)
+
+	// Custom values should override the new defaults
+	require.Equal(t, int32(15), pod.Containers[0].LivenessProbe.TimeoutSeconds)
+	require.Equal(t, int32(25), pod.Containers[0].LivenessProbe.PeriodSeconds)
+	require.Equal(t, int32(5), pod.Containers[0].LivenessProbe.FailureThreshold)
+	require.Equal(t, int32(8), pod.Containers[0].ReadinessProbe.TimeoutSeconds)
+	require.Equal(t, int32(15), pod.Containers[0].ReadinessProbe.PeriodSeconds)
+	require.Equal(t, int32(12), pod.Containers[0].StartupProbe.TimeoutSeconds)
+	require.Equal(t, int32(45), pod.Containers[0].StartupProbe.FailureThreshold)
+}
+
+// TestPegaDeploymentNewHealthProbesDisabledExplicitly verifies that when explicitly set to false,
+// legacy probes are used even with a compatible version.
+func TestPegaDeploymentNewHealthProbesDisabledExplicitly(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":              "eks",
+			"global.actions.execute":       "deploy",
+			"global.deployment.name":       "pega",
+			"global.newHealthProbes.enabled": "false",
+			"global.pegaVersion":           "26.2.0",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+	pod := depObj.Spec.Template.Spec
+
+	// Should use legacy probes
+	verifyLegacyProbes(t, &pod)
+
+	// No fallback warning since it was explicitly disabled
+	require.Empty(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"])
+}
+
+// TestPegaDeploymentNewHealthProbesFutureVersion verifies new probes work with future versions.
+func TestPegaDeploymentNewHealthProbesFutureVersion(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	versions := []string{"27.0.0", "26.5.3", "30.1.0"}
+
+	for _, version := range versions {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"global.provider":              "eks",
+				"global.actions.execute":       "deploy",
+				"global.deployment.name":       "pega",
+				"global.newHealthProbes.enabled": "true",
+				"global.pegaVersion":           version,
+			},
+		}
+
+		yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+		yamlSplit := strings.Split(yamlContent, "---")
+
+		UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+		pod := depObj.Spec.Template.Spec
+
+		verifyNewProbes(t, &pod)
+	}
+}
+
+// verifyLegacyProbes asserts that all probes use the legacy /ping endpoint with legacy defaults.
+func verifyLegacyProbes(t *testing.T, pod *k8score.PodSpec) {
+	t.Helper()
+
+	// Liveness probe - legacy
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/ping", pod.Containers[0].LivenessProbe.HTTPGet.Path)
+	require.Equal(t, k8score.URIScheme("HTTP"), pod.Containers[0].LivenessProbe.HTTPGet.Scheme)
+	require.Equal(t, intstr.FromInt(8081), pod.Containers[0].LivenessProbe.HTTPGet.Port)
+	require.Equal(t, int32(0), pod.Containers[0].LivenessProbe.InitialDelaySeconds)
+	require.Equal(t, int32(20), pod.Containers[0].LivenessProbe.TimeoutSeconds)
+	require.Equal(t, int32(30), pod.Containers[0].LivenessProbe.PeriodSeconds)
+	require.Equal(t, int32(1), pod.Containers[0].LivenessProbe.SuccessThreshold)
+	require.Equal(t, int32(3), pod.Containers[0].LivenessProbe.FailureThreshold)
+
+	// Readiness probe - legacy
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/ping", pod.Containers[0].ReadinessProbe.HTTPGet.Path)
+	require.Equal(t, k8score.URIScheme("HTTP"), pod.Containers[0].ReadinessProbe.HTTPGet.Scheme)
+	require.Equal(t, intstr.FromInt(8080), pod.Containers[0].ReadinessProbe.HTTPGet.Port)
+	require.Equal(t, int32(0), pod.Containers[0].ReadinessProbe.InitialDelaySeconds)
+	require.Equal(t, int32(10), pod.Containers[0].ReadinessProbe.TimeoutSeconds)
+	require.Equal(t, int32(10), pod.Containers[0].ReadinessProbe.PeriodSeconds)
+	require.Equal(t, int32(1), pod.Containers[0].ReadinessProbe.SuccessThreshold)
+	require.Equal(t, int32(3), pod.Containers[0].ReadinessProbe.FailureThreshold)
+
+	// Startup probe - legacy
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/ping", pod.Containers[0].StartupProbe.HTTPGet.Path)
+	require.Equal(t, k8score.URIScheme("HTTP"), pod.Containers[0].StartupProbe.HTTPGet.Scheme)
+	require.Equal(t, intstr.FromInt(8080), pod.Containers[0].StartupProbe.HTTPGet.Port)
+	require.Equal(t, int32(10), pod.Containers[0].StartupProbe.InitialDelaySeconds)
+	require.Equal(t, int32(10), pod.Containers[0].StartupProbe.TimeoutSeconds)
+	require.Equal(t, int32(10), pod.Containers[0].StartupProbe.PeriodSeconds)
+	require.Equal(t, int32(1), pod.Containers[0].StartupProbe.SuccessThreshold)
+	require.Equal(t, int32(30), pod.Containers[0].StartupProbe.FailureThreshold)
+}
+
+// verifyNewProbes asserts that all probes use the new separated endpoints with new defaults.
+func verifyNewProbes(t *testing.T, pod *k8score.PodSpec) {
+	t.Helper()
+
+	// Liveness probe - new separated endpoint
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/liveness", pod.Containers[0].LivenessProbe.HTTPGet.Path)
+	require.Equal(t, k8score.URIScheme("HTTP"), pod.Containers[0].LivenessProbe.HTTPGet.Scheme)
+	require.Equal(t, intstr.FromInt(8081), pod.Containers[0].LivenessProbe.HTTPGet.Port)
+	require.Equal(t, int32(0), pod.Containers[0].LivenessProbe.InitialDelaySeconds)
+	require.Equal(t, int32(5), pod.Containers[0].LivenessProbe.TimeoutSeconds)
+	require.Equal(t, int32(20), pod.Containers[0].LivenessProbe.PeriodSeconds)
+	require.Equal(t, int32(1), pod.Containers[0].LivenessProbe.SuccessThreshold)
+	require.Equal(t, int32(3), pod.Containers[0].LivenessProbe.FailureThreshold)
+
+	// Readiness probe - new separated endpoint
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/readiness", pod.Containers[0].ReadinessProbe.HTTPGet.Path)
+	require.Equal(t, k8score.URIScheme("HTTP"), pod.Containers[0].ReadinessProbe.HTTPGet.Scheme)
+	require.Equal(t, intstr.FromInt(8080), pod.Containers[0].ReadinessProbe.HTTPGet.Port)
+	require.Equal(t, int32(0), pod.Containers[0].ReadinessProbe.InitialDelaySeconds)
+	require.Equal(t, int32(5), pod.Containers[0].ReadinessProbe.TimeoutSeconds)
+	require.Equal(t, int32(10), pod.Containers[0].ReadinessProbe.PeriodSeconds)
+	require.Equal(t, int32(1), pod.Containers[0].ReadinessProbe.SuccessThreshold)
+	require.Equal(t, int32(3), pod.Containers[0].ReadinessProbe.FailureThreshold)
+
+	// Startup probe - new separated endpoint
+	require.Equal(t, "/prweb/PRRestService/monitor/pingService/startup", pod.Containers[0].StartupProbe.HTTPGet.Path)
+	require.Equal(t, k8score.URIScheme("HTTP"), pod.Containers[0].StartupProbe.HTTPGet.Scheme)
+	require.Equal(t, intstr.FromInt(8080), pod.Containers[0].StartupProbe.HTTPGet.Port)
+	require.Equal(t, int32(10), pod.Containers[0].StartupProbe.InitialDelaySeconds)
+	require.Equal(t, int32(5), pod.Containers[0].StartupProbe.TimeoutSeconds)
+	require.Equal(t, int32(10), pod.Containers[0].StartupProbe.PeriodSeconds)
+	require.Equal(t, int32(1), pod.Containers[0].StartupProbe.SuccessThreshold)
+	require.Equal(t, int32(60), pod.Containers[0].StartupProbe.FailureThreshold)
+}

--- a/terratest/src/test/pega/pega-tier-deployment-health-probes_test.go
+++ b/terratest/src/test/pega/pega-tier-deployment-health-probes_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 // TestPegaDeploymentLegacyHealthProbes verifies that when newHealthProbes is not enabled,
-// probes use the legacy /ping endpoint with legacy default values.
+// probes use the legacy /ping endpoint with legacy default values (enhanced probes not active).
 func TestPegaDeploymentLegacyHealthProbes(t *testing.T) {
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
@@ -37,9 +37,9 @@ func TestPegaDeploymentLegacyHealthProbes(t *testing.T) {
 	verifyLegacyProbes(t, &pod)
 }
 
-// TestPegaDeploymentNewHealthProbesEnabled verifies that when newHealthProbes.enabled=true
-// and pegaVersion >= 26.1.1, probes use the new separated endpoints with new defaults.
-func TestPegaDeploymentNewHealthProbesEnabled(t *testing.T) {
+// TestPegaDeploymentEnhancedHealthProbesEnabled verifies that when newHealthProbes.enabled=true
+// and pegaVersion supports enhanced probes (>= 2026.1.1), probes use the new separated endpoints with new defaults.
+func TestPegaDeploymentEnhancedHealthProbesEnabled(t *testing.T) {
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
@@ -51,7 +51,7 @@ func TestPegaDeploymentNewHealthProbesEnabled(t *testing.T) {
 			"global.actions.execute":       "deploy",
 			"global.deployment.name":       "pega",
 			"global.newHealthProbes.enabled": "true",
-			"global.pegaVersion":           "26.2.0",
+			"global.pegaVersion":           "2026.2.0",
 		},
 	}
 
@@ -67,8 +67,8 @@ func TestPegaDeploymentNewHealthProbesEnabled(t *testing.T) {
 	require.Empty(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"])
 }
 
-// TestPegaDeploymentNewHealthProbesWithExactVersion verifies behavior with exact threshold version 26.1.1
-func TestPegaDeploymentNewHealthProbesWithExactVersion(t *testing.T) {
+// TestPegaDeploymentEnhancedHealthProbesWithExactVersion2026 verifies behavior with exact threshold version 2026.1.1
+func TestPegaDeploymentEnhancedHealthProbesWithExactVersion2026(t *testing.T) {
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
@@ -80,7 +80,7 @@ func TestPegaDeploymentNewHealthProbesWithExactVersion(t *testing.T) {
 			"global.actions.execute":       "deploy",
 			"global.deployment.name":       "pega",
 			"global.newHealthProbes.enabled": "true",
-			"global.pegaVersion":           "26.1.1",
+			"global.pegaVersion":           "2026.1.1",
 		},
 	}
 
@@ -90,13 +90,12 @@ func TestPegaDeploymentNewHealthProbesWithExactVersion(t *testing.T) {
 	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
 	pod := depObj.Spec.Template.Spec
 
-	// Exact version 26.1.1 should activate new probes (>= check)
+	// Exact version 2026.1.1 should activate enhanced probes
 	verifyNewProbes(t, &pod)
 }
 
-// TestPegaDeploymentNewHealthProbesFallbackOlderVersion verifies that when newHealthProbes.enabled=true
-// but pegaVersion < 26.1.1, probes fall back to legacy /ping and a warning annotation is added.
-func TestPegaDeploymentNewHealthProbesFallbackOlderVersion(t *testing.T) {
+// TestPegaDeploymentEnhancedHealthProbesWithExactVersion2025 verifies behavior with exact threshold version 2025.1.4
+func TestPegaDeploymentEnhancedHealthProbesWithExactVersion2025(t *testing.T) {
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
@@ -108,7 +107,35 @@ func TestPegaDeploymentNewHealthProbesFallbackOlderVersion(t *testing.T) {
 			"global.actions.execute":       "deploy",
 			"global.deployment.name":       "pega",
 			"global.newHealthProbes.enabled": "true",
-			"global.pegaVersion":           "25.1.0",
+			"global.pegaVersion":           "2025.1.4",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+	pod := depObj.Spec.Template.Spec
+
+	// Exact version 2025.1.4 should activate enhanced probes
+	verifyNewProbes(t, &pod)
+}
+
+// TestPegaDeploymentEnhancedHealthProbesFallbackOlderVersion verifies that when newHealthProbes.enabled=true
+// but pegaVersion is not supported, probes fall back to legacy /ping and a warning annotation is added.
+func TestPegaDeploymentEnhancedHealthProbesFallbackOlderVersion(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":              "eks",
+			"global.actions.execute":       "deploy",
+			"global.deployment.name":       "pega",
+			"global.newHealthProbes.enabled": "true",
+			"global.pegaVersion":           "2025.1.0",
 		},
 	}
 
@@ -123,11 +150,11 @@ func TestPegaDeploymentNewHealthProbesFallbackOlderVersion(t *testing.T) {
 
 	// Should have fallback warning annotation
 	require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "Falling back to legacy /ping probes")
-	require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "25.1.0")
+	require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "2025.1.0")
 }
 
-// TestPegaDeploymentNewHealthProbesFallbackNoVersion verifies fallback when pegaVersion is not set at all.
-func TestPegaDeploymentNewHealthProbesFallbackNoVersion(t *testing.T) {
+// TestPegaDeploymentEnhancedHealthProbesFallbackNoVersion verifies fallback when pegaVersion is not set at all.
+func TestPegaDeploymentEnhancedHealthProbesFallbackNoVersion(t *testing.T) {
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
@@ -155,9 +182,9 @@ func TestPegaDeploymentNewHealthProbesFallbackNoVersion(t *testing.T) {
 	require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "Falling back to legacy /ping probes")
 }
 
-// TestPegaDeploymentNewHealthProbesVersion26_1_0 verifies that version 26.1.0 (just below threshold)
+// TestPegaDeploymentEnhancedHealthProbesVersion2026_1_0 verifies that version 2026.1.0 (just below threshold)
 // falls back to legacy probes.
-func TestPegaDeploymentNewHealthProbesVersion26_1_0(t *testing.T) {
+func TestPegaDeploymentEnhancedHealthProbesVersion2026_1_0(t *testing.T) {
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
@@ -169,7 +196,7 @@ func TestPegaDeploymentNewHealthProbesVersion26_1_0(t *testing.T) {
 			"global.actions.execute":       "deploy",
 			"global.deployment.name":       "pega",
 			"global.newHealthProbes.enabled": "true",
-			"global.pegaVersion":           "26.1.0",
+			"global.pegaVersion":           "2026.1.0",
 		},
 	}
 
@@ -179,16 +206,47 @@ func TestPegaDeploymentNewHealthProbesVersion26_1_0(t *testing.T) {
 	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
 	pod := depObj.Spec.Template.Spec
 
-	// 26.1.0 is below 26.1.1, should use legacy
+	// 2026.1.0 is below 2026.1.1, should use legacy
 	verifyLegacyProbes(t, &pod)
 
 	// Should have fallback warning annotation
 	require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "Falling back to legacy /ping probes")
 }
 
-// TestPegaDeploymentNewHealthProbesAppliedToAllTiers verifies that new probes apply
+// TestPegaDeploymentEnhancedHealthProbesVersion2025_1_3 verifies that version 2025.1.3 (just below threshold)
+// falls back to legacy probes.
+func TestPegaDeploymentEnhancedHealthProbesVersion2025_1_3(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	options := &helm.Options{
+		SetValues: map[string]string{
+			"global.provider":              "eks",
+			"global.actions.execute":       "deploy",
+			"global.deployment.name":       "pega",
+			"global.newHealthProbes.enabled": "true",
+			"global.pegaVersion":           "2025.1.3",
+		},
+	}
+
+	yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+	yamlSplit := strings.Split(yamlContent, "---")
+
+	UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+	pod := depObj.Spec.Template.Spec
+
+	// 2025.1.3 is below 2025.1.4, should use legacy
+	verifyLegacyProbes(t, &pod)
+
+	// Should have fallback warning annotation
+	require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "Falling back to legacy /ping probes")
+}
+
+// TestPegaDeploymentEnhancedHealthProbesAppliedToAllTiers verifies that enhanced probes apply
 // to all tiers (web and batch) when enabled globally.
-func TestPegaDeploymentNewHealthProbesAppliedToAllTiers(t *testing.T) {
+func TestPegaDeploymentEnhancedHealthProbesAppliedToAllTiers(t *testing.T) {
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
@@ -201,7 +259,7 @@ func TestPegaDeploymentNewHealthProbesAppliedToAllTiers(t *testing.T) {
 			"global.actions.execute":       "deploy",
 			"global.deployment.name":       "pega",
 			"global.newHealthProbes.enabled": "true",
-			"global.pegaVersion":           "26.2.0",
+			"global.pegaVersion":           "2026.2.0",
 		},
 	}
 
@@ -217,9 +275,9 @@ func TestPegaDeploymentNewHealthProbesAppliedToAllTiers(t *testing.T) {
 	verifyNewProbes(t, &batchDep.Spec.Template.Spec)
 }
 
-// TestPegaDeploymentNewHealthProbesWithCustomOverrides verifies that user-specified
-// probe values take precedence over new probe defaults.
-func TestPegaDeploymentNewHealthProbesWithCustomOverrides(t *testing.T) {
+// TestPegaDeploymentEnhancedHealthProbesWithCustomOverrides verifies that user-specified
+// probe values take precedence over enhanced probe defaults.
+func TestPegaDeploymentEnhancedHealthProbesWithCustomOverrides(t *testing.T) {
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
@@ -231,7 +289,7 @@ func TestPegaDeploymentNewHealthProbesWithCustomOverrides(t *testing.T) {
 			"global.actions.execute":                  "deploy",
 			"global.deployment.name":                  "pega",
 			"global.newHealthProbes.enabled":            "true",
-			"global.pegaVersion":                      "26.2.0",
+			"global.pegaVersion":                      "2026.2.0",
 			"global.tier[0].name":                     "web",
 			"global.tier[0].livenessProbe.timeoutSeconds":    "15",
 			"global.tier[0].livenessProbe.periodSeconds":     "25",
@@ -264,9 +322,9 @@ func TestPegaDeploymentNewHealthProbesWithCustomOverrides(t *testing.T) {
 	require.Equal(t, int32(45), pod.Containers[0].StartupProbe.FailureThreshold)
 }
 
-// TestPegaDeploymentNewHealthProbesDisabledExplicitly verifies that when explicitly set to false,
+// TestPegaDeploymentEnhancedHealthProbesDisabledExplicitly verifies that when explicitly set to false,
 // legacy probes are used even with a compatible version.
-func TestPegaDeploymentNewHealthProbesDisabledExplicitly(t *testing.T) {
+func TestPegaDeploymentEnhancedHealthProbesDisabledExplicitly(t *testing.T) {
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
@@ -278,7 +336,7 @@ func TestPegaDeploymentNewHealthProbesDisabledExplicitly(t *testing.T) {
 			"global.actions.execute":       "deploy",
 			"global.deployment.name":       "pega",
 			"global.newHealthProbes.enabled": "false",
-			"global.pegaVersion":           "26.2.0",
+			"global.pegaVersion":           "2026.2.0",
 		},
 	}
 
@@ -295,14 +353,14 @@ func TestPegaDeploymentNewHealthProbesDisabledExplicitly(t *testing.T) {
 	require.Empty(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"])
 }
 
-// TestPegaDeploymentNewHealthProbesFutureVersion verifies new probes work with future versions.
-func TestPegaDeploymentNewHealthProbesFutureVersion(t *testing.T) {
+// TestPegaDeploymentEnhancedHealthProbesFutureVersion verifies enhanced probes work with future versions.
+func TestPegaDeploymentEnhancedHealthProbesFutureVersion(t *testing.T) {
 	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
 	require.NoError(t, err)
 
 	var depObj appsv1.Deployment
 
-	versions := []string{"27.0.0", "26.5.3", "30.1.0"}
+	versions := []string{"2027.0.0", "2026.5.3", "2030.1.0", "2025.2.0", "2025.1.5"}
 
 	for _, version := range versions {
 		options := &helm.Options{
@@ -358,6 +416,40 @@ func verifyLegacyProbes(t *testing.T, pod *k8score.PodSpec) {
 	require.Equal(t, int32(10), pod.Containers[0].StartupProbe.PeriodSeconds)
 	require.Equal(t, int32(1), pod.Containers[0].StartupProbe.SuccessThreshold)
 	require.Equal(t, int32(30), pod.Containers[0].StartupProbe.FailureThreshold)
+}
+
+// TestPegaDeploymentEnhancedHealthProbesRejected8xVersion verifies that 8.x versions are rejected.
+func TestPegaDeploymentEnhancedHealthProbesRejected8xVersion(t *testing.T) {
+	helmChartPath, err := filepath.Abs(PegaHelmChartPath)
+	require.NoError(t, err)
+
+	var depObj appsv1.Deployment
+
+	versions := []string{"8.8.0", "8.23.1", "8.7.4"}
+
+	for _, version := range versions {
+		options := &helm.Options{
+			SetValues: map[string]string{
+				"global.provider":              "eks",
+				"global.actions.execute":       "deploy",
+				"global.deployment.name":       "pega",
+				"global.newHealthProbes.enabled": "true",
+				"global.pegaVersion":           version,
+			},
+		}
+
+		yamlContent := RenderTemplate(t, options, helmChartPath, []string{"templates/pega-tier-deployment.yaml"})
+		yamlSplit := strings.Split(yamlContent, "---")
+
+		UnmarshalK8SYaml(t, yamlSplit[1], &depObj)
+		pod := depObj.Spec.Template.Spec
+
+		// All 8.x versions should fall back to legacy probes
+		verifyLegacyProbes(t, &pod)
+
+		// Should have fallback warning annotation
+		require.Contains(t, depObj.ObjectMeta.Annotations["pega.io/health-probes-warning"], "Falling back to legacy /ping probes")
+	}
 }
 
 // verifyNewProbes asserts that all probes use the new separated endpoints with new defaults.


### PR DESCRIPTION
Introduced a version-gated new health probe endpoints for Pega deployments while preserving the existing legacy /ping behavior by default.
When global.newHealthProbes.enabled explicitly set to true (and global.pegaVersion >= 26.1.1) the chart switches probe routing to the new dedicated endpoints:

- /monitor/pingService/startup
- /monitor/pingService/liveness
- /monitor/pingService/readiness

If the feature is enabled on an older Pega version, the chart falls back to legacy /ping probes and adds a deployment annotation warning so the fallback is visible to users.


**Chart changes:** 
- Added global.newHealthProbes.enabled: false to values.yaml. 
- Added helper logic in helpers.tpl to determine whether separated probes are supported. 
- Updated pega-deployment.tpl to: 
  - use new probe endpoints when supported, 
  - keep legacy /ping when not enabled or unsupported, 
  - apply the new startup/liveness/readiness defaults, 
  - add a warning annotation when falling back.
 
**Test coverage**
- default legacy behavior,
- enabled + supported version,
- exact boundary version 26.1.1,
- older version fallback,
- missing version fallback etc..