### PR TITLE
Add X-Request-Id to access logs

### DIFF
--- a/charts/pega/config/deploy/server.xml.tmpl
+++ b/charts/pega/config/deploy/server.xml.tmpl
@@ -233,7 +233,7 @@
              Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log" suffix=".txt"
-               pattern="&quot;%{X-Forwarded-For}i&quot; &quot;%h&quot; &quot;%l&quot; &quot;%u&quot; &quot;%t&quot; &quot;%r&quot; &quot;%s&quot; &quot;%b&quot; &quot;%D&quot; &quot;%I&quot; &quot;%S&quot; &quot;%{User-Agent}i&quot;"
+               pattern="&quot;%{X-Forwarded-For}i&quot; &quot;%h&quot; &quot;%l&quot; &quot;%u&quot; &quot;%t&quot; &quot;%r&quot; &quot;%s&quot; &quot;%b&quot; &quot;%D&quot; &quot;%I&quot; &quot;%S&quot; &quot;%{User-Agent}i&quot; &quot;%{X-Request-Id}i&quot;"
                resolveHosts="false" />
 
         <Valve className="org.apache.catalina.valves.ErrorReportValve"

--- a/terratest/src/test/pega/data/expectedInstallDeployServer.xml.tmpl
+++ b/terratest/src/test/pega/data/expectedInstallDeployServer.xml.tmpl
@@ -233,7 +233,7 @@
              Note: The pattern used is equivalent to using pattern="common" -->
         <Valve className="org.apache.catalina.valves.AccessLogValve" directory="logs"
                prefix="localhost_access_log" suffix=".txt"
-               pattern="&quot;%{X-Forwarded-For}i&quot; &quot;%h&quot; &quot;%l&quot; &quot;%u&quot; &quot;%t&quot; &quot;%r&quot; &quot;%s&quot; &quot;%b&quot; &quot;%D&quot; &quot;%I&quot; &quot;%S&quot; &quot;%{User-Agent}i&quot;"
+               pattern="&quot;%{X-Forwarded-For}i&quot; &quot;%h&quot; &quot;%l&quot; &quot;%u&quot; &quot;%t&quot; &quot;%r&quot; &quot;%s&quot; &quot;%b&quot; &quot;%D&quot; &quot;%I&quot; &quot;%S&quot; &quot;%{User-Agent}i&quot; &quot;%{X-Request-Id}i&quot;"
                resolveHosts="false" />
 
         <Valve className="org.apache.catalina.valves.ErrorReportValve"


### PR DESCRIPTION
## What
Adds the `X-Request-Id` incoming request header to the Tomcat `AccessLogValve` pattern in `server.xml.tmpl`, so it's captured in the localhost access log alongside the existing fields (`X-Forwarded-For`, `User-Agent`, etc.).

## Why
`X-Request-Id` is commonly injected by service mesh sidecars (e.g. Istio/Envoy) for request tracing/correlation across services. Surfacing it in Tomcat's access log makes it much easier to correlate access-log entries with upstream/downstream trace data during debugging.

## Changes
- `charts/pega/config/deploy/server.xml.tmpl`: appended `%{X-Request-Id}i` to the `AccessLogValve` pattern.
- `terratest/src/test/pega/data/expectedInstallDeployServer.xml.tmpl`: updated golden test fixture to match.

## Testing
- `helm dependency build` + full `go test ./pega/...` terratest suite passes locally.